### PR TITLE
Feat - add option to fetch or skip user info endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ test/version_tmp
 .tool-version
 .ruby-gemset
 Gemfile.lock
+.tool-versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Released]
 
+## [0.2.0] - 2024-07-06
+- Add option to fetch user info or skip it
+
 ## [0.1.1] - 2024-06-16
 - Add dependabot
 

--- a/lib/omniauth/oidc/version.rb
+++ b/lib/omniauth/oidc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniauthOidc
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/lib/omniauth/strategies/oidc.rb
+++ b/lib/omniauth/strategies/oidc.rb
@@ -61,6 +61,7 @@ module OmniAuth
       option :id_token_hint
       option :acr_values
       option :send_nonce, true
+      option :fetch_user_info, true
       option :send_scope_to_token_endpoint, true
       option :client_auth_method
       option :post_logout_redirect_uri

--- a/lib/omniauth/strategies/oidc/callback.rb
+++ b/lib/omniauth/strategies/oidc/callback.rb
@@ -58,7 +58,7 @@ module OmniAuth
 
           verify_id_token!(@access_token.id_token) if configured_response_type == "code"
 
-          user_info_from_access_token
+          options.fetch_user_info ? user_info_from_access_token : define_access_token
         end
 
         def id_token_callback_phase
@@ -95,6 +95,20 @@ module OmniAuth
             uid: user_data["sub"],
             info: { name: user_data["name"], email: user_data["email"] },
             extra: { raw_info: user_data },
+            credentials: {
+              id_token: @access_token.id_token,
+              token: @access_token.access_token,
+              refresh_token: @access_token.refresh_token,
+              expires_in: @access_token.expires_in,
+              scope: @access_token.scope
+            }
+          )
+          call_app!
+        end
+
+        def define_access_token
+          env["omniauth.auth"] = AuthHash.new(
+            provider: name,
             credentials: {
               id_token: @access_token.id_token,
               token: @access_token.access_token,


### PR DESCRIPTION
Referring to the [issue](https://github.com/msuliq/omniauth_oidc/issues/2) an optional parameters `fetch_user_info` has been added for those applications which do not need to hit `user_info_endpoint` to collect information on the authenticating user and instead only rely on the access token received from the OIDC provider 