### PR TITLE
update dependencies for rack and openid_connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Released]
 
+## [0.2.0] - 2024-07-21
+- Update dependencies
+
 ## [0.2.0] - 2024-07-06
 - Add option to fetch user info or skip it
 

--- a/lib/omniauth/oidc/version.rb
+++ b/lib/omniauth/oidc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniauthOidc
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/lib/omniauth/strategies/oidc.rb
+++ b/lib/omniauth/strategies/oidc.rb
@@ -5,7 +5,7 @@ require "timeout"
 require "net/http"
 require "open-uri"
 require "omniauth"
-require "openid_connect"
+require "oidc"
 require "openid_config_parser"
 require "forwardable"
 require "httparty"
@@ -112,9 +112,9 @@ module OmniAuth
         }
       end
 
-      # Initialize OpenIDConnect Client with options
+      # Initialize Oidc Client with options
       def client
-        @client ||= ::OpenIDConnect::Client.new(client_options)
+        @client ||= ::Oidc::Client.new(client_options)
       end
 
       # Config is build from the json response from the OIDC config endpoint

--- a/lib/omniauth/strategies/oidc/verify.rb
+++ b/lib/omniauth/strategies/oidc/verify.rb
@@ -30,7 +30,7 @@ module OmniAuth
         private
 
         def fetch_key
-          @fetch_key ||= parse_jwk_key(::OpenIDConnect.http_client.get(config.jwks_uri).body)
+          @fetch_key ||= parse_jwk_key(::Oidc.http_client.get(config.jwks_uri).body)
         end
 
         def base64_decoded_jwt_secret
@@ -47,7 +47,6 @@ module OmniAuth
                                             nonce: params["nonce"].presence || stored_nonce)
         end
 
-        # Workaround for https://github.com/nov/openid_connect/issues/61
         def decode_id_token(id_token)
           decoded = JSON::JWT.decode(id_token, :skip_verification)
           algorithm = decoded.algorithm.to_sym
@@ -63,7 +62,7 @@ module OmniAuth
             end
 
           decoded.verify!(keyset)
-          ::OpenIDConnect::ResponseObject::IdToken.new(decoded)
+          ::Oidc::ResponseObject::IdToken.new(decoded)
         rescue JSON::JWK::Set::KidNotFound
           # Workaround for https://github.com/nov/json-jwt/pull/92#issuecomment-824654949
           raise if decoded&.header&.key?("kid")
@@ -88,7 +87,7 @@ module OmniAuth
         end
 
         def decode!(id_token, key)
-          ::OpenIDConnect::ResponseObject::IdToken.decode(id_token, key)
+          ::Oidc::ResponseObject::IdToken.decode(id_token, key)
         end
 
         def decode_with_each_key!(id_token, keyset)
@@ -140,7 +139,7 @@ module OmniAuth
           if access_token.id_token
             decoded = decode_id_token(access_token.id_token).raw_attributes
 
-            @user_info = ::OpenIDConnect::ResponseObject::UserInfo.new(
+            @user_info = ::Oidc::ResponseObject::UserInfo.new(
               access_token.userinfo!.raw_attributes.merge(decoded)
             )
           else

--- a/omniauth_oidc.gemspec
+++ b/omniauth_oidc.gemspec
@@ -33,9 +33,9 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "httparty"
+  spec.add_dependency "oidc"
   spec.add_dependency "omniauth"
   spec.add_dependency "openid_config_parser"
-  spec.add_dependency "openid_connect"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
Referring to the [issue #4](https://github.com/msuliq/omniauth_oidc/issues/4) dependencies were updated to allow latest `omniauth` and `rack`.

These dependencies were enforced by the `openid_connect` library which has been replaced by a forked version without any dependency versions specified. Forked version might be replaced by the original `openid_connect` once it implements version-free dependencies.