### PR TITLE
fix for unitialized constant oidc in strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Released]
 
+## [0.2.5] - 2024-10-16
+- Fix for uninitialized constant Oidc in strategy.rb:163
+
 ## [0.2.4] - 2024-09-28
 - Fix bug with configurable scopes
 

--- a/lib/omniauth/oidc/version.rb
+++ b/lib/omniauth/oidc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniauthOidc
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end

--- a/lib/omniauth/strategies/oidc.rb
+++ b/lib/omniauth/strategies/oidc.rb
@@ -30,7 +30,7 @@ module OmniAuth
 
       def_delegator :request, :params
 
-      option :name, "oidc"                                  # to separate each oidc provider available in the app
+      option :name, :oidc                                   # to separate each oidc provider available in the app
       option(:client_options, identifier: nil,              # client id, required
                               secret: nil,                  # client secret, required
                               host: nil,                    # oidc provider host, optional

--- a/lib/omniauth/strategies/oidc/verify.rb
+++ b/lib/omniauth/strategies/oidc/verify.rb
@@ -30,7 +30,7 @@ module OmniAuth
         private
 
         def fetch_key
-          @fetch_key ||= parse_jwk_key(::Oidc.http_client.get(config.jwks_uri).body)
+          @fetch_key ||= parse_jwk_key(::OpenIDConnect.http_client.get(config.jwks_uri).body)
         end
 
         def base64_decoded_jwt_secret


### PR DESCRIPTION
Fixes following error:
`[61432:puma srv tp 001 strategy.rb:163] Authentication failure! uninitialized constant Oidc: NameError, uninitialized constant Oidc`