### PR TITLE
version v1.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Ruby 2.7
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,10 +7,10 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.7.0"
+          ruby-version: "3.3"
           bundler-cache: true
       - run: bundle exec rubocop
   test:
@@ -18,16 +18,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7.0", "3.2.1"]
+        ruby: ["2.7.0", "3.2.1", "4.0.1"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Bundle audit
-        run: bundle exec bundle-audit --update
-      - name: Install dependencies
-        run: bundle install
+        run: bundle exec bundle-audit check --update
       - name: Run tests
         run: bundle exec rake test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   TargetRubyVersion: 2.7
+  NewCops: enable
 
 Style/StringLiterals:
   Enabled: true
@@ -21,7 +22,7 @@ Metrics/MethodLength:
 Metrics/AbcSize:
   Max: 35
 
-Metrics/Metrics/CyclomaticComplexity:
+Metrics/CyclomaticComplexity:
   Max: 10
 
 Metrics/PerceivedComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,75 @@
 ## [Released]
 
+## [1.0.0] - 2026-03-02
+
+### BREAKING CHANGES
+- **Dependency Replacement**: Removed `openid_connect`, `openid_config_parser`, `json-jwt`, and `httparty` runtime dependencies. Replaced with custom `Net::HTTP`-based implementation and the standard `jwt` gem. Any code that relied on these gems being transitively available will need to add them directly.
+- **Internal Object Types Changed**: Response objects are now custom classes instead of OpenIDConnect library types:
+  - `OpenIDConnect::Client` replaced by `OmniauthOidc::Client`
+  - `OpenIDConnect::ResponseObject::IdToken` replaced by `OmniauthOidc::ResponseObjects::IdToken`
+  - `OpenIDConnect::ResponseObject::UserInfo` replaced by `OmniauthOidc::ResponseObjects::UserInfo`
+  - `Rack::OAuth2::AccessToken` replaced by `OmniauthOidc::ResponseObjects::AccessToken`
+- **Session Keys Namespaced**: Session keys now include the provider name (e.g. `omniauth.my_provider.state` instead of `omniauth.state`). This enables multiple OIDC providers but breaks code that manually accesses session keys with the old format. Users mid-authentication during upgrade will see state mismatch errors.
+- **Scope Return Type**: `scope` now returns a space-delimited String (e.g. `"openid profile email"`) instead of an Array. Code that called `.each`, `.include?`, or other Array methods on the return value will break.
+- **AuthHash Construction**: Now uses OmniAuth DSL blocks (`info`, `credentials`, `extra`) consistently instead of manually building `env["omniauth.auth"]`. The `info` hash now includes all standard OIDC UserInfo fields (given_name, family_name, gender, picture, phone, website).
+- **Error Classes Restructured**: Error handling uses new specific error classes under `OmniauthOidc::` namespace. `Rack::OAuth2::Client::Error` is no longer caught. `validate_client_algorithm!` now raises `OmniauthOidc::InvalidAlgorithmError` instead of `CallbackError`.
+- **CallbackError Parameter Names**: `CallbackError` now accepts `error_reason:` and `error_uri:` keyword arguments (previously `reason:` and `uri:`). The old keys are still accepted for backward compatibility.
+
+### Added
+- **Custom HTTP Client** (`OmniauthOidc::HttpClient`): Net::HTTP-based client for all HTTP requests, removing external HTTP client dependencies entirely
+  - GET requests follow up to 5 redirects (301, 302, 307, 308), including relative redirects
+  - POST requests reject redirects to prevent credential leakage
+- **Custom OIDC Client** (`OmniauthOidc::Client`): Handles authorization URI construction, token exchange, and userinfo fetching
+- **Response Objects** (`OmniauthOidc::ResponseObjects`): `IdToken`, `UserInfo`, and `AccessToken` classes with method-style access to standard OIDC claims
+- **Configuration Fetcher** (`OmniauthOidc::ConfigFetcher`): Fetches and parses `.well-known/openid-configuration` with retry support
+- **JWK Handler** (`OmniauthOidc::JwkHandler`): JWKS parsing with proper `kid`-based key selection for providers that publish multiple signing keys (e.g. Google, Microsoft Entra ID, Auth0)
+- **JWKS Caching** (`OmniauthOidc::JwksCache`): Thread-safe JWKS cache with configurable TTL (default 1 hour)
+  - Automatic cache invalidation and retry on signature verification failure
+  - Manual cache control via `OmniauthOidc::JwksCache.clear!` and `.invalidate(uri)`
+  - Configurable via `jwks_cache_ttl` option
+- **Logging & Instrumentation** (`OmniauthOidc::Logging`): Logging via Ruby Logger with optional ActiveSupport::Notifications integration
+  - Configurable log levels (default: WARN)
+  - Automatic sanitization of sensitive data (tokens, secrets, code verifiers)
+  - Event instrumentation for config fetch, token exchange, userinfo fetch, JWKS fetch, request phase, and callback phase
+- **Error Hierarchy**: Specific error classes for all failure modes
+  - `TokenVerificationError`, `TokenExpiredError`, `InvalidAlgorithmError`, `InvalidSignatureError`
+  - `InvalidIssuerError`, `InvalidAudienceError`, `InvalidNonceError`
+  - `JwksFetchError`, `KeyNotFoundError`
+  - `ConfigurationError`, `MissingConfigurationError`
+- **Configuration Validation**: Required options (`identifier`, `secret`, `config_endpoint`) are validated on first request with a clear error message listing all missing fields
+- **RBS Type Signatures** (`sig/omniauth_oidc.rbs`): Full type declarations for all public API classes
+- **Comprehensive Test Suite**: Unit tests for HTTP client, JWK handler, JWKS cache, logging, errors, and strategy configuration
+
+### Fixed
+- **JWK kid Selection**: `keyset_for_algorithm` now selects the correct signing key by `kid` from JWKS. Previously, with multiple keys in the JWKS, verification could fail or use the wrong key.
+- **Dead Code Removed**: Removed `decode` method in Verify module that referenced undefined `UrlSafeBase64` constant
+- **Typo**: Fixed `client_singing_alg` to `client_signing_alg` in error messages
+- **Scope Default**: Fixed default scope fallback from `[:open_id]` (typo) to `[:openid]`
+- **AuthHash Consistency**: Consolidated duplicate user info fetching and AuthHash construction into OmniAuth DSL blocks
+- **Removed `resolve_endpoint_from_host`**: Endpoints are now used as full URLs from the discovery document instead of being stripped to relative paths
+
+### Changed
+- **Module Loading**: Replaced `Dir.glob` with explicit `require_relative` for clarity and predictable load order
+- **Dependency Constraints**: Runtime dependencies reduced to `omniauth ~> 2.1` and `jwt ~> 2.7`
+- **CI Updates**: Added Ruby 4.0.1 to test matrix, updated `actions/checkout` to v6, RuboCop runs on Ruby 3.3
+- **RuboCop Config**: Fixed invalid cop name `Metrics/Metrics/CyclomaticComplexity`, added `NewCops: enable`
+
+### Migration Guide from 0.x to 1.0.0
+
+1. **Dependencies**: Remove gems that were only used by this gem, then run `bundle install`:
+   - `httparty`
+   - `openid_connect`
+   - `openid_config_parser`
+   - `json-jwt`
+2. **Session Keys**: If you manually access session keys, update to the new namespaced format: `omniauth.{provider_name}.state`, `omniauth.{provider_name}.nonce`.
+3. **Scope Handling**: If your code treats `scope` as an Array, update it. `scope` now returns a space-delimited String.
+4. **Error Handling**: Update rescue clauses to catch the new error classes if needed. For example:
+   - `Rack::OAuth2::Client::Error` -> `OmniauthOidc::TokenError`
+   - Algorithm mismatches now raise `OmniauthOidc::InvalidAlgorithmError` instead of `CallbackError`
+5. **Response Objects**: If you access `access_token` or `user_info` objects directly, note they are now `OmniauthOidc::ResponseObjects::AccessToken` and `OmniauthOidc::ResponseObjects::UserInfo` respectively.
+6. **Logging** (optional): Configure logging level: `OmniauthOidc::Logging.log_level = Logger::INFO`
+7. **Ruby 4.0+**: Add `gem "ostruct"` to your Gemfile (removed from default gems in Ruby 4.0).
+
 ## [0.2.7] - 2024-10-11
 - Dependencies update
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,13 @@ end
 
 gemspec
 
+# Ruby 4.0+ compatibility
+gem "ostruct" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("4.0.0")
+
 group :development, :test do
   gem "bundle-audit"
   gem "minitest"
+  gem "rack-test"
   gem "rake"
   gem "rubocop"
   gem "webmock"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2024 Suleyman Musayev
+Copyright (c) 2024-present Suleyman Musayev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # OmniAuth::Oidc
 
-This gem provides an OmniAuth strategy for integrating OpenID Connect (OIDC) authentication into your Ruby on Rails application. It allows seamless login using various OIDC providers.
+OmniAuth strategy for OpenID Connect (OIDC) authentication. Supports multiple OIDC providers, PKCE, JWKS key rotation, and both `code` and `id_token` response types.
+
+Minimal dependencies: only `omniauth` and `jwt` gems required. All HTTP requests use Ruby's built-in `Net::HTTP` — no Faraday, HTTParty, or other external HTTP clients.
 
 Developed with reference to [omniauth-openid-connect](https://github.com/jjbohn/omniauth-openid-connect) and [omniauth_openid_connect](https://github.dev/omniauth/omniauth_openid_connect).
 
@@ -16,14 +18,15 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
     $ gem install omniauth_oidc
 
+**Ruby 4.0+**: Add `gem "ostruct"` to your Gemfile (`ostruct` was removed from default gems in Ruby 4.0).
 
 ## Usage
 
 To use the OmniAuth OIDC strategy, you need to configure your Rails application and set up the necessary environment variables for OIDC client credentials.
 
 ### Configuration
-You have to provide Client ID, Client Secret and url for the OIDC configuration endpoint as a bare minimum for the `omniauth_oidc` to work properly.
-Create an initializer file at `config/initializers/omniauth.rb`
+
+You must provide Client ID, Client Secret, and the URL for the OIDC configuration endpoint as a minimum for `omniauth_oidc` to work. Create an initializer file at `config/initializers/omniauth.rb`:
 
 ```ruby
 # config/initializers/omniauth.rb
@@ -39,13 +42,13 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 ```
 
-With Devise
+With Devise:
 
 ```ruby
 Devise.setup do |config|
   config.omniauth :oidc, {
     name: :simple_provider,
-    scope: [:openid, :email, :profile, :address],
+    scope: %w[openid email profile address],
     response_type: :code,
     uid_field: "preferred_username",
     client_options: {
@@ -57,7 +60,7 @@ Devise.setup do |config|
 end
 ```
 
-The gem also supports a wide range of optional parameters for higher degree of configurability.
+The gem also supports a wide range of optional parameters for a higher degree of configurability:
 
 ```ruby
 # config/initializers/omniauth.rb
@@ -65,7 +68,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :oidc, {
     name: :complex_provider, # used for dynamic routing
     issuer: 'https://complexprovider.com/cdn-cgi/access/sso/oidc/23575f4602bebbd9a17dbc38d85bd1a77',
-    scope: [:openid],
+    scope: %w[openid],
     response_type: 'id_token',
     require_state: true,
     response_mode: :query,
@@ -73,24 +76,25 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     send_nonce: false,
     uid_field: "sub",
     pkce: false,
+    jwks_cache_ttl: 3600, # JWKS cache TTL in seconds (default: 3600)
     client_options: {
       identifier: '23575f4602bebbd9a17dbc38d85bd1a77',
       secret: ENV['COMPLEX_PROVIDER_CLIENT_SECRET'],
       config_endpoint: 'https://complexprovider.com/cdn-cgi/access/sso/oidc/23575f4602bebbd9a17dbc38d85bd1a77/.well-known/openid-configuration',
-      host: 'complexprovider.com'
+      host: 'complexprovider.com',
       scheme: "https",
       port: 443,
       authorization_endpoint: 'https://complexprovider.com/cdn-cgi/access/sso/oidc/23575f4602bebbd9a17dbc38d85bd1a77/authorization',
       token_endpoint: 'https://complexprovider.com/cdn-cgi/access/sso/oidc/23575f4602bebbd9a17dbc38d85bd1a77/token',
       userinfo_endpoint: 'https://complexprovider.com/cdn-cgi/access/sso/oidc/23575f4602bebbd9a17dbc38d85bd1a77/userinfo',
       jwks_uri: 'https://complexprovider.com/cdn-cgi/access/sso/oidc/23575f4602bebbd9a17dbc38d85bd1a77/jwks',
-      end_session_endpoint: '/signout'
+      end_session_endpoint: 'https://complexprovider.com/signout'
     }
   }
 end
 ```
 
-Ensure to replace identifier, secret, configuration endpoint url and others with credentials received from your OIDC provider.
+Ensure to replace identifier, secret, configuration endpoint URL and others with credentials received from your OIDC provider.
 Please note that the gem does not accept `redirect_uri` as a configurable option. For details please see section Routes.
 
 ### Redirecting for Authentication
@@ -103,7 +107,7 @@ Buttons and links to initialize the authentication request can be placed on rele
 
 ### Handling Callbacks
 
-The gem uses dyanmic routes to handle different phases, and while you can use same routes in your Rails application, for
+The gem uses dynamic routes to handle different phases, and while you can use same routes in your Rails application, for
 better experience you should have a controller to process the authenticated user. Create a CallbacksController:
 
 ```ruby
@@ -113,9 +117,9 @@ class CallbacksController < ApplicationController
     # user info received from OIDC provider will be available in `request.env['omniauth.auth']`
     auth = request.env['omniauth.auth']
 
-    user = User.find_or_create_by(uid: auth['uid']) do |user|
-      user.name = auth['info']['name']
-      user.email = auth['info']['email']
+    user = User.find_or_create_by(uid: auth['uid']) do |u|
+      u.name = auth['info']['name']
+      u.email = auth['info']['email']
     end
 
     session[:user_id] = user.id
@@ -124,17 +128,48 @@ class CallbacksController < ApplicationController
 end
 ```
 
+The `omniauth.auth` hash includes:
+
+```ruby
+{
+  provider: :simple_provider,
+  uid: "user123",
+  info: {
+    name: "Test User",
+    email: "test@example.com",
+    email_verified: true,
+    nickname: "testuser",         # preferred_username
+    first_name: "Test",           # given_name
+    last_name: "User",            # family_name
+    gender: "male",
+    image: "https://example.com/avatar.jpg",  # picture
+    phone: "+1234567890",         # phone_number
+    urls: { website: "https://testuser.com" }
+  },
+  credentials: {
+    id_token: "eyJ...",
+    token: "access_token_value",
+    refresh_token: "refresh_token_value",
+    expires_in: 3600,
+    scope: "openid profile email"
+  },
+  extra: {
+    raw_info: { ... }  # full userinfo response attributes
+  }
+}
+```
+
 ### Routes
 
 The gem uses dynamic routes when making requests to the OIDC provider endpoints, so called `redirect_uri` which is a
-non-configurable value that follows the naming pattern of `https://your_app.com/auth/<simple_provider>/callback`, 
+non-configurable value that follows the naming pattern of `https://your_app.com/auth/<simple_provider>/callback`,
 where `<simple_provider>` is the provider name defined within the configuration of the `omniauth.rb` initializer.
 This represents the `redirect_uri` that will be passed with the authorization request to your OIDC provider and that
 has to be registered with your OIDC provider as permitted `redirect_uri`.
 
 Dynamic routes are used to process responses and perform intermediary steps by the middleware, e.g. request phase,
-token verification. While you can define and use same routes within your Rails app, it is highly recommended to modify 
-your `routes.rb` to perform a dynamic redirect to a another controller method so this does not cause any conflicts with
+token verification. While you can define and use same routes within your Rails app, it is highly recommended to modify
+your `routes.rb` to perform a dynamic redirect to another controller method so this does not cause any conflicts with
 the middleware or the authorization flow.
 
 In an example below, `auth/:provider/callback` is generalized `redirect_uri` value that is passed in the authorization
@@ -163,11 +198,11 @@ end
 ```
 
 **Please note that you should register `https://your_app.com/auth/<simple_provider>/callback` with your OIDC provider
-as a callback redirect url.**
+as a callback redirect URL.**
 
 ### Using Access Token Without User Info
 
-In case your app requries only an access token and not the user information, then you can specify an optional
+In case your app requires only an access token and not the user information, then you can specify an optional
 configuration in the omniauth initializer:
 
 ```ruby
@@ -185,38 +220,17 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 ```
 
-Then the callback returned once your user authenticates with the OIDC provider will contain only access token parameters:
-
-```ruby
-# app/controllers/callbacks_controller.rb
-class CallbacksController < ApplicationController
-  def omniauth
-    # access token parameters received from OIDC provider will be available in `request.env['omniauth.auth']`
-    omniauth_params = request.env['omniauth.auth']
-
-    # omniauth_params will contain similar data as shown below
-    # {"provider"=>:simple_provider_access_token_only,
-    #  "credentials"=>
-    #   {"id_token"=> "id token value",
-    #    "token"=> "token value",
-    #    "refresh_token"=>"refresh token value",
-    #    "expires_in"=>300,
-    #    "scope"=>nil
-    #   }
-    # }
-  end
-end
-```
+When `fetch_user_info` is `false`, user info is extracted from the ID token claims instead of calling the userinfo endpoint. If the userinfo endpoint call fails, the gem also falls back to ID token claims automatically.
 
 ### Ending Session
 
 The gem provides two configuration options to allow ending a session simultaneously with your client application and the
 OIDC provider.
 
-To use this feature, you need to provide a `logout_path` in the options and an `end_session_endpoint` in the client 
-options. Here’s a sample setup:
+To use this feature, you need to provide a `logout_path` in the options and an `end_session_endpoint` in the client
+options. Here's a sample setup:
 
-``` ruby
+```ruby
   provider :oidc, {
     name: :simple_provider,
     client_options: {
@@ -236,32 +250,76 @@ options. Here’s a sample setup:
 Using these two configurations, you can ensure that when a user logs out from your application, they are also logged out
 from the OIDC provider, providing a seamless logout across multiple services.
 
-This works by calling `other_phase` on every controller request in your application. The method checks if the requested 
-URL matches the defined `logout_path`. If it does (i.e. current user has requested to log out from your application) 
-`other_phase` performs a redirect to the `end_session_endpoint` to terminate the user's session with the OIDC provider 
+This works by calling `other_phase` on every controller request in your application. The method checks if the requested
+URL matches the defined `logout_path`. If it does (i.e. current user has requested to log out from your application)
+`other_phase` performs a redirect to the `end_session_endpoint` to terminate the user's session with the OIDC provider
 and then it returns back to your application and concludes the request to end the current user's session.
 
 For additional details please refer to the [OIDC specification](https://openid.net/specs/openid-connect-session-1_0-17.html#:~:text=%C2%A0TOC-,5.%C2%A0%20RP%2DInitiated%20Logout,-An%20RP%20can).
 
+### Logging
+
+The gem includes built-in logging with automatic sensitive data sanitization. By default, log level is set to WARN.
+
+```ruby
+# Set log level
+OmniauthOidc::Logging.log_level = Logger::INFO
+
+# Use a custom logger
+OmniauthOidc::Logging.logger = Rails.logger
+```
+
+If ActiveSupport::Notifications is available (e.g. in Rails), the gem publishes instrumentation events:
+
+- `config.fetch.omniauth_oidc` — OIDC discovery document fetch
+- `token.exchange.omniauth_oidc` — authorization code to token exchange
+- `userinfo.fetch.omniauth_oidc` — userinfo endpoint call
+- `jwks.fetch.omniauth_oidc` — JWKS fetch
+- `request_phase.start.omniauth_oidc` — authorization redirect
+- `callback_phase.start.omniauth_oidc` — callback processing
+- `id_token.verify.omniauth_oidc` — ID token verification
+
+### Error Handling
+
+The gem raises specific error classes that you can rescue in your callback handling:
+
+| Error Class | When Raised |
+|---|---|
+| `OmniauthOidc::MissingConfigurationError` | Required options (`identifier`, `secret`, `config_endpoint`) are missing |
+| `OmniauthOidc::ConfigurationError` | OIDC discovery endpoint fetch fails |
+| `OmniauthOidc::TokenError` | Token exchange fails |
+| `OmniauthOidc::TokenVerificationError` | JWT format is invalid |
+| `OmniauthOidc::TokenExpiredError` | ID token `exp` claim is in the past |
+| `OmniauthOidc::InvalidAlgorithmError` | JWT algorithm does not match `client_signing_alg` |
+| `OmniauthOidc::InvalidSignatureError` | JWT signature verification fails |
+| `OmniauthOidc::InvalidIssuerError` | ID token `iss` does not match expected issuer |
+| `OmniauthOidc::InvalidAudienceError` | ID token `aud` does not match client identifier |
+| `OmniauthOidc::InvalidNonceError` | ID token `nonce` does not match stored nonce |
+| `OmniauthOidc::JwksFetchError` | JWKS endpoint fetch fails |
+
+All error classes inherit from `OmniauthOidc::Error < RuntimeError`.
+
 ### Advanced Configuration
+
 You can customize the OIDC strategy further by adding additional configuration options:
 
 | Field                        | Description                                                                                                                                                           | Required                | Default Value                       | Example/Notes                                         |
 |------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|-------------------------------------|-------------------------------------------------------|
 | name                         | Arbitrary string to identify OIDC provider and segregate it from other OIDC providers                                                                                 | no                      | `"oidc"`                            | `:simple_provider`                                    |
-| issuer                       | Root url for the OIDC authorization server                                                                                                                            | no                      | retrived from config_endpoint       | `"https://simpleprovider.com"`                        |
-| fetch_user_info              | Fetches user information from user_info_endpoint using the access token. If set to false the omniauth params will include only access token                           | no                      | `true`                              | `fetch_user_info: false`                              |
-| client_auth_method           | Authentication method to be used with the OIDC authorization server                                                                                                   | no                      | `:basic`                            | `"basic"`, `"jwks"`                                   |
-| scope                        | OIDC scopes to be included in the server's response                                                                                                                   | `[:openid]` is required | all scopes offered by OIDC provider | `[:openid, :profile, :email]`                         |
+| issuer                       | Root url for the OIDC authorization server                                                                                                                            | no                      | retrieved from config_endpoint      | `"https://simpleprovider.com"`                        |
+| fetch_user_info              | Fetches user information from userinfo endpoint using the access token. If false, user info is extracted from ID token claims                                          | no                      | `true`                              | `fetch_user_info: false`                              |
+| client_signing_alg           | Expected JWT signing algorithm. If set, tokens signed with a different algorithm are rejected                                                                          | no                      | `nil` (any algorithm accepted)      | `"RS256"`, `"HS256"`                                  |
+| scope                        | OIDC scopes to request. Accepts Array or String; always sent as a space-delimited string                                                                              | `openid` is required    | all scopes offered by OIDC provider | `%w[openid profile email]`                            |
 | response_type                | OAuth2 response type expected from OIDC provider during authorization                                                                                                 | no                      | `"code"`                            | `"code"` or `"id_token"`                              |
 | state                        | Value to be used for the OAuth2 state parameter on the authorization request. Can be a proc that generates a string                                                   | no                      | Random 16 character string          | `Proc.new { SecureRandom.hex(32) }`                   |
 | require_state                | Boolean to indicate if state param should be verified. This is a recommendation by OIDC spec                                                                          | no                      | `true`                              | `true` or `false`                                     |
 | response_mode                | The response mode per [OIDC spec](https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html)                                                                 | no                      | `nil`                               | `:query`, `:fragment`, `:form_post` or `:web_message` |
 | display                      | Specifies how OIDC authorization server should display the authentication and consent UI pages to the end user                                                        | no                      | `nil`                               | `:page`, `:popup`, `:touch` or `:wap`                 |
 | prompt                       | Specifies whether the OIDC authorization server prompts the end user for reauthentication and consent                                                                 | no                      | `nil`                               | `:none`, `:login`, `:consent` or `:select_account`    |
+| send_nonce                   | Include a nonce in the authorization request and verify it in the ID token                                                                                            | no                      | `true`                              | `true` or `false`                                     |
 | send_scope_to_token_endpoint | Should the scope parameter be sent to the authorization token endpoint                                                                                                | no                      | `true`                              | `true` or `false`                                     |
 | post_logout_redirect_uri     | Logout redirect uri to use per the [session management draft](https://openid.net/specs/openid-connect-session-1_0.html)                                               | no                      | `nil`                               | `"https://your_app.com/logout/callback"`              |
-| uid_field                    | Field of the user info response to be used as a unique ID                                                                                                             | no                      | `'sub'`                             | `"sub"` or `"preferred_username"`                     |
+| uid_field                    | Field of the user info response to be used as a unique ID                                                                                                             | no                      | `"sub"`                             | `"sub"` or `"preferred_username"`                     |
 | extra_authorize_params       | Hash of extra fixed parameters that will be merged to the authorization request                                                                                       | no                      | `{}`                                | `{"tenant" => "common"}`                              |
 | allow_authorize_params       | List of allowed dynamic parameters that will be merged to the authorization request                                                                                   | no                      | `[]`                                | `[:screen_name]`                                      |
 | pkce                         | Enable [PKCE flow](https://oauth.net/2/pkce/)                                                                                                                         | no                      | `false`                             | `true` or `false`                                     |
@@ -269,9 +327,13 @@ You can customize the OIDC strategy further by adding additional configuration o
 | pkce_options                 | Specify custom implementation of the PKCE code challenge/method                                                                                                       | no                      | SHA256(code_challenge) in hex       | Proc to customise the code challenge generation       |
 | client_options               | Hash of client options detailed below in a separate table                                                                                                             | yes                     | see below                           | see below                                             |
 | jwt_secret_base64            | Specify the base64-encoded secret used to sign the JWT token for HMAC with SHA2 (e.g. HS256) signing algorithms                                                       | no                      | `client_options.secret`             | `"bXlzZWNyZXQ=\n"`                                    |
-| logout_path                  | Log out is only triggered when the request path ends on this path                                                                                                     | no                      | `'/logout'`                         | '/sign_out'                                           |
-| acr_values                   | Authentication Class Reference (ACR) values to be passed to the authorize_uri to enforce a specific level, see [RFC9470](https://www.rfc-editor.org/rfc/rfc9470.html) | no                      | `nil`                               | `"c1 c2"`                                             å|
-
+| client_jwk_signing_key       | JWK or JWKS (as JSON string or Hash) for local signature verification without fetching from `jwks_uri`                                                                | no                      | `nil`                               | `'{"kty":"RSA","n":"...","e":"AQAB"}'`                |
+| client_x509_signing_key      | X.509 certificate (PEM format) for local signature verification                                                                                                       | no                      | `nil`                               | PEM string                                            |
+| logout_path                  | Log out is only triggered when the request path ends on this path                                                                                                     | no                      | `"/logout"`                         | `"/sign_out"`                                         |
+| jwks_cache_ttl               | JWKS cache time-to-live in seconds                                                                                                                                    | no                      | `3600` (1 hour)                     | `7200`                                                |
+| hd                           | Google-specific: hosted domain parameter                                                                                                                              | no                      | `nil`                               | `"example.com"`                                       |
+| max_age                      | Maximum authentication age in seconds                                                                                                                                 | no                      | `nil`                               | `3600`                                                |
+| acr_values                   | Authentication Class Reference (ACR) values per [RFC9470](https://www.rfc-editor.org/rfc/rfc9470.html)                                                                | no                      | `nil`                               | `"c1 c2"`                                             |
 
 Below are options for the `client_options` hash of the configuration:
 
@@ -280,14 +342,14 @@ Below are options for the `client_options` hash of the configuration:
 | identifier             | OAuth2 client_id                                            |    yes   | `nil`                         |
 | secret                 | OAuth2 client secret                                        |    yes   | `nil`                         |
 | config_endpoint        | OIDC configuration endpoint                                 |    yes   | `nil`                         |
-| scheme                 | http scheme to use                                          |     no   | https                         |
-| host                   | host of the authorization server                            |     no   | nil                           |
-| port                   | port for the authorization server                           |     no   | 443                           |
-| authorization_endpoint | authorize endpoint on the authorization server              |     no   | retrived from config_endpoint |
-| token_endpoint         | token endpoint on the authorization server                  |     no   | retrived from config_endpoint |
-| userinfo_endpoint      | user info endpoint on the authorization server              |     no   | retrived from config_endpoint |
-| jwks_uri               | jwks_uri on the authorization server                        |     no   | retrived from config_endpoint |
-| end_session_endpoint   | url to call to log the user out at the authorization server |     no   | `nil`                         |
+| scheme                 | HTTP scheme to use                                          |     no   | `"https"`                     |
+| host                   | Host of the authorization server                            |     no   | `nil`                         |
+| port                   | Port for the authorization server                           |     no   | `443`                         |
+| authorization_endpoint | Authorize endpoint on the authorization server              |     no   | retrieved from config_endpoint |
+| token_endpoint         | Token endpoint on the authorization server                  |     no   | retrieved from config_endpoint |
+| userinfo_endpoint      | User info endpoint on the authorization server              |     no   | retrieved from config_endpoint |
+| jwks_uri               | JWKS URI on the authorization server                        |     no   | retrieved from config_endpoint |
+| end_session_endpoint   | URL to call to log the user out at the authorization server |     no   | `nil`                         |
 
 ## Contributing
 

--- a/lib/omniauth/oidc/client.rb
+++ b/lib/omniauth/oidc/client.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "base64"
+
+module OmniauthOidc
+  # Custom OIDC client using Net::HTTP
+  class Client
+    attr_accessor :identifier, :secret, :authorization_endpoint, :token_endpoint, :userinfo_endpoint,
+                  :host, :redirect_uri
+
+    def initialize(options = {})
+      @identifier = options[:identifier] || options["identifier"]
+      @secret = options[:secret] || options["secret"]
+      @authorization_endpoint = options[:authorization_endpoint] || options["authorization_endpoint"]
+      @token_endpoint = options[:token_endpoint] || options["token_endpoint"]
+      @userinfo_endpoint = options[:userinfo_endpoint] || options["userinfo_endpoint"]
+      @redirect_uri = options[:redirect_uri] || options["redirect_uri"]
+    end
+
+    def authorization_uri(params = {})
+      uri = URI.parse(authorization_endpoint)
+      query_params = {
+        client_id: identifier,
+        response_type: params[:response_type] || "code",
+        scope: params[:scope] || "openid profile email",
+        redirect_uri: params[:redirect_uri] || @redirect_uri,
+        state: params[:state],
+        nonce: params[:nonce]
+      }.compact
+
+      # Add PKCE parameters if provided
+      query_params[:code_challenge] = params[:code_challenge] if params[:code_challenge]
+      query_params[:code_challenge_method] = params[:code_challenge_method] if params[:code_challenge_method]
+
+      # Add any additional params
+      query_params.merge!(params[:extra_params]) if params[:extra_params]
+
+      uri.query = URI.encode_www_form(query_params)
+      uri.to_s
+    end
+
+    def access_token!(params = {}) # rubocop:disable Metrics/MethodLength
+      body_params = {
+        grant_type: "authorization_code",
+        code: params[:code],
+        redirect_uri: params[:redirect_uri] || @redirect_uri,
+        client_id: identifier,
+        client_secret: secret
+      }
+
+      # Add PKCE verifier if provided
+      body_params[:code_verifier] = params[:code_verifier] if params[:code_verifier]
+
+      OmniauthOidc::Logging.instrument("token.exchange", code: "[FILTERED]") do
+        response = HttpClient.post(
+          token_endpoint,
+          body: URI.encode_www_form(body_params),
+          headers: {
+            "Content-Type" => "application/x-www-form-urlencoded",
+            "Accept" => "application/json"
+          }
+        )
+
+        ResponseObjects::AccessToken.new(response)
+      end
+    rescue HttpClient::HttpError => e
+      raise OmniauthOidc::TokenError, "Token exchange failed: #{e.message}"
+    end
+
+    def userinfo!(access_token)
+      OmniauthOidc::Logging.instrument("userinfo.fetch", endpoint: userinfo_endpoint) do
+        response = HttpClient.get(
+          userinfo_endpoint,
+          headers: {
+            "Authorization" => "Bearer #{access_token}",
+            "Accept" => "application/json"
+          }
+        )
+
+        ResponseObjects::UserInfo.new(response)
+      end
+    rescue HttpClient::HttpError => e
+      raise OmniauthOidc::TokenError, "Failed to fetch user info: #{e.message}"
+    end
+  end
+end

--- a/lib/omniauth/oidc/config_fetcher.rb
+++ b/lib/omniauth/oidc/config_fetcher.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module OmniauthOidc
+  # Fetches and parses OpenID Connect configuration from .well-known endpoint
+  class ConfigFetcher
+    # Config object with dynamic attribute access for OIDC discovery fields
+    class Config
+      def initialize(attributes = {})
+        @attributes = attributes
+      end
+
+      def [](key)
+        @attributes[key.to_sym] || @attributes[key.to_s]
+      end
+
+      def []=(key, value)
+        @attributes[key.to_sym] = value
+        @attributes[key.to_s] = value
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        setter = method_name.to_s.end_with?("=")
+        key = setter ? method_name.to_s.chomp("=") : method_name.to_s
+        setter || @attributes.key?(key.to_sym) || @attributes.key?(key) || super
+      end
+
+      private
+
+      def method_missing(method_name, *args)
+        name = method_name.to_s
+
+        if name.end_with?("=")
+          key = name.chomp("=")
+          @attributes[key.to_sym] = args.first
+          @attributes[key] = args.first
+        elsif @attributes.key?(name.to_sym)
+          @attributes[name.to_sym]
+        elsif @attributes.key?(name)
+          @attributes[name]
+        else
+          super
+        end
+      end
+    end
+
+    class << self
+      def fetch(endpoint_url, max_retries: 3)
+        retries = 0
+        begin
+          response = OmniauthOidc::HttpClient.get(endpoint_url)
+          symbolized_config = deep_symbolize_keys(response)
+          Config.new(symbolized_config)
+        rescue OmniauthOidc::HttpClient::HttpError => e
+          retries += 1
+          retry if retries < max_retries
+          raise OmniauthOidc::ConfigurationError, "Failed to fetch OIDC configuration: #{e.message}"
+        rescue StandardError => e
+          raise OmniauthOidc::ConfigurationError, "Failed to fetch OIDC configuration: #{e.message}"
+        end
+      end
+
+      private
+
+      # Recursively converts keys of a hash to symbols while retaining the original string keys
+      def deep_symbolize_keys(hash)
+        result = {}
+        hash.each do |key, value|
+          sym_key = key.to_sym
+          result[sym_key] = value.is_a?(Hash) ? deep_symbolize_keys(value) : value
+          result[key] = result[sym_key] # Add the string key as well
+        end
+        result
+      end
+    end
+  end
+end

--- a/lib/omniauth/oidc/errors.rb
+++ b/lib/omniauth/oidc/errors.rb
@@ -3,7 +3,26 @@
 module OmniauthOidc
   class Error < RuntimeError; end
 
+  # Authentication flow errors
   class MissingCodeError < Error; end
-
   class MissingIdTokenError < Error; end
+
+  # Configuration errors
+  class ConfigurationError < Error; end
+  class MissingConfigurationError < ConfigurationError; end
+
+  # Token/JWT errors
+  class TokenError < Error; end
+  class TokenVerificationError < TokenError; end
+  class TokenExpiredError < TokenError; end
+  class InvalidAlgorithmError < TokenError; end
+  class InvalidSignatureError < TokenError; end
+  class InvalidIssuerError < TokenError; end
+  class InvalidAudienceError < TokenError; end
+  class InvalidNonceError < TokenError; end
+
+  # JWKS errors
+  class JwksError < Error; end
+  class JwksFetchError < JwksError; end
+  class KeyNotFoundError < JwksError; end
 end

--- a/lib/omniauth/oidc/http_client.rb
+++ b/lib/omniauth/oidc/http_client.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "uri"
+require "json"
+
+module OmniauthOidc
+  # Simple HTTP client using Net::HTTP
+  class HttpClient
+    class HttpError < StandardError; end
+
+    MAX_REDIRECTS = 5
+
+    def self.get(url, headers: {})
+      uri = URI.parse(url)
+      request = Net::HTTP::Get.new(uri)
+      headers.each { |key, value| request[key] = value }
+
+      response = execute_request(uri, request)
+      handle_response(response, url, headers: headers, redirects_remaining: MAX_REDIRECTS)
+    end
+
+    def self.post(url, body: nil, headers: {})
+      uri = URI.parse(url)
+      request = Net::HTTP::Post.new(uri)
+      request["Content-Type"] = "application/x-www-form-urlencoded" unless headers["Content-Type"]
+      headers.each { |key, value| request[key] = value }
+      request.body = body if body
+
+      response = execute_request(uri, request)
+      handle_response(response, url)
+    end
+
+    def self.execute_request(uri, request)
+      OmniauthOidc::Logging.instrument("http.request", method: request.method, uri: uri.to_s) do
+        Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") do |http|
+          http.request(request)
+        end
+      end
+    end
+    private_class_method :execute_request
+
+    def self.handle_response(response, url, headers: {}, redirects_remaining: 0)
+      case response
+      when Net::HTTPSuccess
+        parse_json_response(response.body)
+      when Net::HTTPRedirection
+        raise HttpError, "Too many redirects for #{url}" if redirects_remaining <= 0
+
+        location = response["location"]
+        raise HttpError, "HTTP redirect from #{url} with no location header" unless location
+
+        redirect_uri = URI.parse(location)
+        # Resolve relative redirects
+        redirect_uri = URI.join(url, location) unless redirect_uri.host
+
+        OmniauthOidc::Logging.debug("Following redirect", from: url, to: redirect_uri.to_s)
+        follow_redirect(redirect_uri, headers: headers, redirects_remaining: redirects_remaining - 1)
+      else
+        raise HttpError, "HTTP request failed: #{response.code} #{response.message} for #{url}"
+      end
+    end
+    private_class_method :handle_response
+
+    def self.follow_redirect(uri, headers: {}, redirects_remaining: 0)
+      request = Net::HTTP::Get.new(uri)
+      headers.each { |key, value| request[key] = value }
+
+      response = execute_request(uri, request)
+      handle_response(response, uri.to_s, headers: headers, redirects_remaining: redirects_remaining)
+    end
+    private_class_method :follow_redirect
+
+    def self.parse_json_response(body)
+      JSON.parse(body)
+    rescue JSON::ParserError => e
+      raise HttpError, "Failed to parse JSON response: #{e.message}"
+    end
+    private_class_method :parse_json_response
+  end
+end

--- a/lib/omniauth/oidc/jwk_handler.rb
+++ b/lib/omniauth/oidc/jwk_handler.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "jwt"
+require "openssl"
+
+module OmniauthOidc
+  # Handles JWK/JWKS operations for JWT verification
+  class JwkHandler
+    # Parsed key with its kid for matching
+    KeyWithId = Struct.new(:kid, :keypair, keyword_init: true)
+
+    def self.parse_jwks(jwks_data)
+      return nil unless jwks_data
+
+      jwks_data = JSON.parse(jwks_data) if jwks_data.is_a?(String)
+
+      # Handle JWKS (set of keys)
+      if jwks_data["keys"]
+        jwks_data["keys"].filter_map { |key_data| jwk_to_key(key_data) }
+      # Handle single JWK
+      else
+        [jwk_to_key(jwks_data)].compact
+      end
+    end
+
+    def self.jwk_to_key(jwk_data)
+      keypair = JWT::JWK.import(jwk_data).keypair
+      kid = jwk_data["kid"] || jwk_data[:kid]
+      KeyWithId.new(kid: kid, keypair: keypair)
+    rescue StandardError => e
+      OmniauthOidc::Logging.error("Failed to import JWK", error: e.message)
+      nil
+    end
+
+    # Find the right key from JWKS based on kid (key ID)
+    def self.find_key(keys, kid = nil)
+      return keys.first&.keypair if kid.nil? || keys.size <= 1
+
+      matched = keys.find { |k| k.kid == kid }
+      if matched
+        matched.keypair
+      else
+        OmniauthOidc::Logging.warn("No JWK found matching kid '#{kid}', falling back to first key")
+        keys.first&.keypair
+      end
+    end
+  end
+end

--- a/lib/omniauth/oidc/jwks_cache.rb
+++ b/lib/omniauth/oidc/jwks_cache.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module OmniauthOidc
+  # Thread-safe JWKS cache with configurable TTL and force refresh capability
+  class JwksCache
+    DEFAULT_TTL = 3600 # 1 hour in seconds
+
+    CacheEntry = Struct.new(:keys, :fetched_at, keyword_init: true)
+
+    class << self
+      def instance
+        @instance ||= new
+      end
+
+      # Clear all cached keys (useful for testing)
+      def clear!
+        instance.clear!
+      end
+
+      # Force refresh a specific JWKS URI on next access
+      def invalidate(jwks_uri)
+        instance.invalidate(jwks_uri)
+      end
+    end
+
+    def initialize(ttl: DEFAULT_TTL)
+      @ttl = ttl
+      @cache = {}
+      @mutex = Mutex.new
+    end
+
+    # Fetch JWKS, using cache if valid
+    def fetch(jwks_uri, force_refresh: false, &block)
+      @mutex.synchronize do
+        entry = @cache[jwks_uri]
+
+        if !force_refresh && entry && !expired?(entry)
+          Logging.debug("JWKS cache hit", jwks_uri: jwks_uri)
+          return entry.keys
+        end
+
+        Logging.info("JWKS cache miss, fetching", jwks_uri: jwks_uri, force_refresh: force_refresh)
+        keys = block.call
+        @cache[jwks_uri] = CacheEntry.new(keys: keys, fetched_at: Time.now)
+        keys
+      end
+    end
+
+    # Check if a specific URI's cache is valid
+    def valid?(jwks_uri)
+      @mutex.synchronize do
+        entry = @cache[jwks_uri]
+        entry && !expired?(entry)
+      end
+    end
+
+    # Invalidate a specific URI's cache
+    def invalidate(jwks_uri)
+      @mutex.synchronize do
+        @cache.delete(jwks_uri)
+        Logging.debug("JWKS cache invalidated", jwks_uri: jwks_uri)
+      end
+    end
+
+    # Clear entire cache
+    def clear!
+      @mutex.synchronize do
+        @cache.clear
+        Logging.debug("JWKS cache cleared")
+      end
+    end
+
+    # Get current TTL
+    attr_reader :ttl
+
+    # Update TTL (affects future expiration checks)
+    def ttl=(value)
+      @mutex.synchronize do
+        @ttl = value
+      end
+    end
+
+    private
+
+    def expired?(entry)
+      Time.now - entry.fetched_at > @ttl
+    end
+  end
+end

--- a/lib/omniauth/oidc/logging.rb
+++ b/lib/omniauth/oidc/logging.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "logger"
+
+module OmniauthOidc
+  # Logging module providing both Ruby Logger and ActiveSupport::Notifications support
+  module Logging
+    class << self
+      attr_writer :logger
+
+      def logger
+        @logger ||= default_logger
+      end
+
+      def log_level=(level)
+        logger.level = level
+      end
+
+      def instrument(event_name, payload = {}, &block)
+        full_event_name = "#{event_name}.omniauth_oidc"
+
+        # Always log the event
+        log_event(event_name, payload)
+
+        # Use ActiveSupport::Notifications if available
+        if defined?(ActiveSupport::Notifications)
+          ActiveSupport::Notifications.instrument(full_event_name, payload, &block)
+        elsif block
+          yield payload
+        end
+      end
+
+      def debug(message, context = {})
+        log(:debug, message, context)
+      end
+
+      def info(message, context = {})
+        log(:info, message, context)
+      end
+
+      def warn(message, context = {})
+        log(:warn, message, context)
+      end
+
+      def error(message, context = {})
+        log(:error, message, context)
+      end
+
+      private
+
+      def default_logger
+        Logger.new($stdout).tap do |log|
+          log.progname = "OmniauthOidc"
+          log.level = Logger::WARN # Default to WARN to avoid noise
+        end
+      end
+
+      def log(level, message, context)
+        formatted_message = context.empty? ? message : "#{message} #{context.inspect}"
+        logger.send(level, formatted_message)
+      end
+
+      def log_event(event_name, payload)
+        # Log at debug level for instrumentation events
+        sanitized_payload = sanitize_payload(payload)
+        debug("Event: #{event_name}", sanitized_payload)
+      end
+
+      def sanitize_payload(payload)
+        # Remove sensitive data from logs
+        sensitive_keys = %i[secret client_secret access_token id_token refresh_token code_verifier]
+        payload.reject { |k, _| sensitive_keys.include?(k.to_sym) }
+      end
+    end
+  end
+end

--- a/lib/omniauth/oidc/response_objects.rb
+++ b/lib/omniauth/oidc/response_objects.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+module OmniauthOidc
+  # Simple response objects to replace OpenIDConnect::ResponseObject classes
+  module ResponseObjects
+    # Represents an OIDC ID Token with claims
+    class IdToken
+      attr_reader :raw_attributes
+
+      def initialize(attributes = {})
+        @raw_attributes = attributes.is_a?(Hash) ? attributes : attributes.to_h
+      end
+
+      def sub
+        raw_attributes["sub"]
+      end
+
+      def iss
+        raw_attributes["iss"]
+      end
+
+      def aud
+        raw_attributes["aud"]
+      end
+
+      def exp
+        raw_attributes["exp"]
+      end
+
+      def iat
+        raw_attributes["iat"]
+      end
+
+      def nonce
+        raw_attributes["nonce"]
+      end
+
+      # Allow method-style access to claims
+      def method_missing(method_name, *args)
+        return raw_attributes[method_name.to_s] if raw_attributes.key?(method_name.to_s)
+
+        super
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        raw_attributes.key?(method_name.to_s) || super
+      end
+    end
+
+    # Represents OIDC UserInfo response
+    class UserInfo
+      attr_reader :raw_attributes
+
+      def initialize(attributes = {})
+        @raw_attributes = attributes.is_a?(Hash) ? attributes : attributes.to_h
+      end
+
+      # Standard OIDC claims
+      def sub
+        raw_attributes["sub"]
+      end
+
+      def name
+        raw_attributes["name"]
+      end
+
+      def given_name
+        raw_attributes["given_name"]
+      end
+
+      def family_name
+        raw_attributes["family_name"]
+      end
+
+      def middle_name
+        raw_attributes["middle_name"]
+      end
+
+      def nickname
+        raw_attributes["nickname"]
+      end
+
+      def preferred_username
+        raw_attributes["preferred_username"]
+      end
+
+      def profile
+        raw_attributes["profile"]
+      end
+
+      def picture
+        raw_attributes["picture"]
+      end
+
+      def website
+        raw_attributes["website"]
+      end
+
+      def email
+        raw_attributes["email"]
+      end
+
+      def email_verified
+        raw_attributes["email_verified"]
+      end
+
+      def gender
+        raw_attributes["gender"]
+      end
+
+      def birthdate
+        raw_attributes["birthdate"]
+      end
+
+      def zoneinfo
+        raw_attributes["zoneinfo"]
+      end
+
+      def locale
+        raw_attributes["locale"]
+      end
+
+      def phone_number
+        raw_attributes["phone_number"]
+      end
+
+      def phone_number_verified
+        raw_attributes["phone_number_verified"]
+      end
+
+      def address
+        raw_attributes["address"]
+      end
+
+      def updated_at
+        raw_attributes["updated_at"]
+      end
+
+      # Allow method-style access to custom claims
+      def method_missing(method_name, *args)
+        return raw_attributes[method_name.to_s] if raw_attributes.key?(method_name.to_s)
+
+        super
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        raw_attributes.key?(method_name.to_s) || super
+      end
+    end
+
+    # Represents an OAuth2 Access Token
+    class AccessToken
+      attr_reader :access_token, :token_type, :expires_in, :refresh_token, :scope, :id_token
+
+      def initialize(attributes = {})
+        @access_token = attributes["access_token"] || attributes[:access_token]
+        @token_type = attributes["token_type"] || attributes[:token_type]
+        @expires_in = attributes["expires_in"] || attributes[:expires_in]
+        @refresh_token = attributes["refresh_token"] || attributes[:refresh_token]
+        @scope = attributes["scope"] || attributes[:scope]
+        @id_token = attributes["id_token"] || attributes[:id_token]
+      end
+
+      def to_h
+        {
+          "access_token" => access_token,
+          "token_type" => token_type,
+          "expires_in" => expires_in,
+          "refresh_token" => refresh_token,
+          "scope" => scope,
+          "id_token" => id_token
+        }.compact
+      end
+    end
+  end
+end

--- a/lib/omniauth/oidc/version.rb
+++ b/lib/omniauth/oidc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniauthOidc
-  VERSION = "0.2.7"
+  VERSION = "1.0.0"
 end

--- a/lib/omniauth/strategies/oidc.rb
+++ b/lib/omniauth/strategies/oidc.rb
@@ -5,16 +5,19 @@ require "timeout"
 require "net/http"
 require "open-uri"
 require "omniauth"
-require "openid_connect"
-require "openid_config_parser"
 require "forwardable"
-require "httparty"
+require "jwt"
+require "ostruct"
+require "openssl"
 
-Dir[File.join(File.dirname(__FILE__), "oidc", "*.rb")].sort.each { |file| require_relative file }
+# Explicit requires instead of Dir glob for clarity and load order control
+require_relative "oidc/request"
+require_relative "oidc/callback"
+require_relative "oidc/verify"
 
 module OmniAuth
   module Strategies
-    # OIDC strategy for omniauth
+    # OIDC strategy for OmniAuth
     class Oidc
       include OmniAuth::Strategy
       include Request
@@ -27,6 +30,8 @@ module OmniAuth
         "id_token" => { exception_class: OmniauthOidc::MissingIdTokenError, key: :missing_id_token }.freeze,
         "code" => { exception_class: OmniauthOidc::MissingCodeError, key: :missing_code }.freeze
       }.freeze
+
+      REQUIRED_OPTIONS = %i[identifier secret config_endpoint].freeze
 
       def_delegator :request, :params
 
@@ -79,6 +84,9 @@ module OmniAuth
 
       option :logout_path, "/logout"
 
+      # JWKS cache configuration
+      option :jwks_cache_ttl, 3600 # 1 hour default
+
       def uid
         user_info.raw_attributes[options.uid_field.to_sym] || user_info.sub
       end
@@ -104,27 +112,44 @@ module OmniAuth
 
       credentials do
         {
-          id_token: access_token.id_token,
-          token: access_token.access_token,
-          refresh_token: access_token.refresh_token,
-          expires_in: access_token.expires_in,
-          scope: access_token.scope
+          id_token: access_token&.id_token,
+          token: access_token&.access_token,
+          refresh_token: access_token&.refresh_token,
+          expires_in: access_token&.expires_in,
+          scope: access_token&.scope
         }
       end
 
-      # Initialize OpenIDConnect Client with options
+      # Initialize our custom OIDC Client with options
       def client
-        @client ||= ::OpenIDConnect::Client.new(client_options)
+        @client ||= begin
+          set_client_endpoints
+          OmniauthOidc::Client.new(
+            identifier: client_options.identifier,
+            secret: client_options.secret,
+            authorization_endpoint: client_options.authorization_endpoint,
+            token_endpoint: client_options.token_endpoint,
+            userinfo_endpoint: client_options.userinfo_endpoint,
+            redirect_uri: redirect_uri
+          )
+        end
       end
 
-      # Config is build from the json response from the OIDC config endpoint
-      def config
-        unless client_options.config_endpoint || params["config_endpoint"]
-          raise Error,
-                "Configuration endpoint is missing from options"
-        end
+      def set_client_endpoints
+        client_options.authorization_endpoint ||= config.authorization_endpoint
+        client_options.token_endpoint ||= config.token_endpoint
+        client_options.userinfo_endpoint ||= config.userinfo_endpoint
+        client_options.jwks_uri ||= config.jwks_uri
+        client_options.end_session_endpoint ||= config.end_session_endpoint
+      end
 
-        @config ||= OpenidConfigParser.fetch_openid_configuration(client_options.config_endpoint)
+      # Config is built from the json response from the OIDC config endpoint
+      def config
+        validate_configuration!
+
+        @config ||= OmniauthOidc::Logging.instrument("config.fetch", config_endpoint: client_options.config_endpoint) do
+          OmniauthOidc::ConfigFetcher.fetch(client_options.config_endpoint)
+        end
       end
 
       # Detects if current request is for the logout url and makes a redirect to end session with OIDC provider
@@ -148,6 +173,18 @@ module OmniAuth
 
       private
 
+      def validate_configuration!
+        missing = []
+        missing << :identifier if client_options.identifier.to_s.empty?
+        missing << :secret if client_options.secret.to_s.empty?
+        missing << :config_endpoint if client_options.config_endpoint.to_s.empty?
+
+        return if missing.empty?
+
+        raise OmniauthOidc::MissingConfigurationError,
+              "Missing required configuration: #{missing.join(", ")}"
+      end
+
       def issuer
         @issuer ||= config.issuer
       end
@@ -158,7 +195,8 @@ module OmniAuth
 
       # By default Returns all scopes supported by the OIDC provider
       def scope
-        options.scope || config.scopes_supported || [:open_id]
+        value = options.scope || config.scopes_supported || [:openid]
+        value.is_a?(Array) ? value.join(" ") : value
       end
 
       def authorization_code
@@ -169,12 +207,21 @@ module OmniAuth
         options.client_options
       end
 
+      # Session key helpers with provider namespacing
+      def session_key(suffix)
+        "omniauth.#{name}.#{suffix}"
+      end
+
       def stored_state
-        session.delete("omniauth.state")
+        session.delete(session_key("state"))
       end
 
       def new_nonce
-        session["omniauth.nonce"] = SecureRandom.hex(16)
+        session[session_key("nonce")] = SecureRandom.hex(16)
+      end
+
+      def stored_nonce
+        session.delete(session_key("nonce"))
       end
 
       def script_name
@@ -210,14 +257,6 @@ module OmniAuth
         @logout_path_pattern ||= /\A#{Regexp.quote(request.base_url)}#{options.logout_path}/
       end
 
-      # Strips port and host from strings with OIDC endpoints
-      def resolve_endpoint_from_host(host, endpoint)
-        start_index = endpoint.index(host) + host.length
-        endpoint = endpoint[start_index..]
-        endpoint = "/#{endpoint}" unless endpoint.start_with?("/")
-        endpoint
-      end
-
       # Override for the CallbackError class
       class CallbackError < StandardError
         attr_accessor :error, :error_reason, :error_uri
@@ -225,8 +264,8 @@ module OmniAuth
         def initialize(data)
           super
           self.error = data[:error]
-          self.error_reason = data[:reason]
-          self.error_uri = data[:uri]
+          self.error_reason = data[:error_reason] || data[:reason]
+          self.error_uri = data[:error_uri] || data[:uri]
         end
 
         def message

--- a/lib/omniauth/strategies/oidc/callback.rb
+++ b/lib/omniauth/strategies/oidc/callback.rb
@@ -3,67 +3,138 @@
 module OmniAuth
   module Strategies
     class Oidc
-      # Callback phase
-      module Callback
-        def callback_phase # rubocop:disable Metrics
-          error = params["error_reason"] || params["error"]
-          error_description = params["error_description"] || params["error_reason"]
-          invalid_state = (options.require_state && params["state"].to_s.empty?) || params["state"] != stored_state
+      # Callback phase - handles OIDC provider response
+      module Callback # rubocop:disable Metrics/ModuleLength
+        def callback_phase
+          OmniauthOidc::Logging.instrument("callback_phase.start", provider: name) do
+            handle_callback_errors do
+              validate_callback_params!
 
-          raise CallbackError, error: params["error"], reason: error_description, uri: params["error_uri"] if error
-          raise CallbackError, error: :csrf_detected, reason: "Invalid 'state' parameter" if invalid_state
+              options.issuer = issuer if options.issuer.nil? || options.issuer.empty?
 
-          return unless valid_response_type?
+              verify_id_token!(params["id_token"]) if configured_response_type == "id_token"
 
-          options.issuer = issuer if options.issuer.nil? || options.issuer.empty?
+              client.redirect_uri = redirect_uri
 
-          verify_id_token!(params["id_token"]) if configured_response_type == "id_token"
+              if configured_response_type == "id_token"
+                handle_id_token_response
+              else
+                handle_code_response
+              end
 
-          client.redirect_uri = redirect_uri
-
-          return id_token_callback_phase if configured_response_type == "id_token"
-
-          client.authorization_code = authorization_code
-
-          access_token
-        rescue CallbackError => e
-          fail!(e.error, e)
-        rescue ::Rack::OAuth2::Client::Error => e
-          fail!(e.response[:error], e)
-        rescue ::Timeout::Error, ::Errno::ETIMEDOUT => e
-          fail!(:timeout, e)
-        rescue ::SocketError => e
-          fail!(:failed_to_connect, e)
+              super
+            end
+          end
         end
 
         private
 
-        def access_token
-          return @access_token if @access_token
-
-          token_request_params = {
-            scope: (scope if options.send_scope_to_token_endpoint),
-            client_auth_method: options.client_auth_method
-          }
-
-          if options.pkce
-            token_request_params[:code_verifier] =
-              params["code_verifier"] || session.delete("omniauth.pkce.verifier")
-          end
-
-          set_client_options_for_callback_phase
-
-          @access_token = client.access_token!(token_request_params)
-
-          verify_id_token!(@access_token.id_token) if configured_response_type == "code"
-
-          options.fetch_user_info ? user_info_from_access_token : define_access_token
+        def handle_callback_errors
+          yield
+        rescue CallbackError => e
+          OmniauthOidc::Logging.error("Callback error", error: e.error, reason: e.error_reason)
+          fail!(e.error, e)
+        rescue OmniauthOidc::TokenError => e
+          OmniauthOidc::Logging.error("Token error", error: e.class.name, message: e.message)
+          fail!(:token_error, e)
+        rescue OmniauthOidc::HttpClient::HttpError => e
+          OmniauthOidc::Logging.error("HTTP error", message: e.message)
+          fail!(:http_error, e)
+        rescue ::Timeout::Error, ::Errno::ETIMEDOUT => e
+          OmniauthOidc::Logging.error("Timeout error", message: e.message)
+          fail!(:timeout, e)
+        rescue ::SocketError => e
+          OmniauthOidc::Logging.error("Connection error", message: e.message)
+          fail!(:failed_to_connect, e)
         end
 
-        def id_token_callback_phase
-          user_data = decode_id_token(params["id_token"]).raw_attributes
+        def validate_callback_params! # rubocop:disable Naming/PredicateMethod
+          error = params["error_reason"] || params["error"]
+          error_description = params["error_description"] || params["error_reason"]
+          invalid_state = (options.require_state && params["state"].to_s.empty?) || params["state"] != stored_state
 
-          define_user_info(user_data)
+          if error
+            raise CallbackError, error: params["error"], error_reason: error_description,
+                                 error_uri: params["error_uri"]
+          end
+          raise CallbackError, error: :csrf_detected, error_reason: "Invalid 'state' parameter" if invalid_state
+
+          valid_response_type?
+        end
+
+        def handle_code_response
+          # Get access token via token exchange
+          @access_token = fetch_access_token
+
+          # Verify the ID token from the token response
+          verify_id_token!(@access_token.id_token) if @access_token.id_token
+
+          # Fetch and set user info
+          @user_info = fetch_user_info
+        end
+
+        def handle_id_token_response
+          # For id_token response type, extract user data directly from the token
+          decoded_token = decode_id_token(params["id_token"])
+          @user_info = OmniauthOidc::ResponseObjects::UserInfo.new(decoded_token.raw_attributes)
+
+          # Create a minimal access token structure for credentials
+          @access_token = OmniauthOidc::ResponseObjects::AccessToken.new(
+            id_token: params["id_token"],
+            access_token: nil,
+            refresh_token: nil,
+            expires_in: nil,
+            scope: nil
+          )
+        end
+
+        def fetch_access_token
+          OmniauthOidc::Logging.instrument("token.exchange", provider: name) do
+            token_request_params = {
+              code: authorization_code,
+              redirect_uri: redirect_uri
+            }
+
+            if options.pkce
+              token_request_params[:code_verifier] =
+                params["code_verifier"] || session.delete(session_key("pkce.verifier"))
+            end
+
+            set_client_options_for_callback_phase
+
+            client.access_token!(token_request_params)
+          end
+        end
+
+        def fetch_user_info
+          return minimal_user_info_from_token unless options.fetch_user_info
+
+          OmniauthOidc::Logging.instrument("userinfo.fetch", provider: name) do
+            # Use our custom client to fetch userinfo
+            userinfo_data = client.userinfo!(@access_token.access_token).raw_attributes
+
+            # Merge with ID token claims if available
+            if @access_token.id_token
+              id_token_claims = decode_id_token(@access_token.id_token).raw_attributes
+              userinfo_data = id_token_claims.merge(userinfo_data)
+            end
+
+            OmniauthOidc::ResponseObjects::UserInfo.new(userinfo_data)
+          end
+        rescue StandardError => e
+          OmniauthOidc::Logging.warn("Failed to fetch userinfo, falling back to ID token", error: e.message)
+          minimal_user_info_from_token
+        end
+
+        def minimal_user_info_from_token
+          return empty_user_info unless @access_token&.id_token
+
+          decoded = decode_id_token(@access_token.id_token)
+          OmniauthOidc::ResponseObjects::UserInfo.new(decoded.raw_attributes)
+        end
+
+        def empty_user_info
+          OmniauthOidc::ResponseObjects::UserInfo.new({})
         end
 
         def valid_response_type?
@@ -75,50 +146,6 @@ module OmniAuth
           false
         end
 
-        def user_info_from_access_token
-          user_data = HTTParty.get(
-            config.userinfo_endpoint, {
-              headers: {
-                "Authorization" => "Bearer #{@access_token}",
-                "Content-Type" => "application/json"
-              }
-            }
-          )
-
-          define_user_info(user_data.parsed_response)
-        end
-
-        def define_user_info(user_data)
-          env["omniauth.auth"] = AuthHash.new(
-            provider: name,
-            uid: user_data["sub"],
-            info: { name: user_data["name"], email: user_data["email"] },
-            extra: { raw_info: user_data },
-            credentials: {
-              id_token: @access_token.id_token,
-              token: @access_token.access_token,
-              refresh_token: @access_token.refresh_token,
-              expires_in: @access_token.expires_in,
-              scope: @access_token.scope
-            }
-          )
-          call_app!
-        end
-
-        def define_access_token
-          env["omniauth.auth"] = AuthHash.new(
-            provider: name,
-            credentials: {
-              id_token: @access_token.id_token,
-              token: @access_token.access_token,
-              refresh_token: @access_token.refresh_token,
-              expires_in: @access_token.expires_in,
-              scope: @access_token.scope
-            }
-          )
-          call_app!
-        end
-
         def configured_response_type
           @configured_response_type ||= options.response_type.to_s
         end
@@ -127,9 +154,19 @@ module OmniAuth
         def set_client_options_for_callback_phase
           client.host = host
           client.redirect_uri = redirect_uri
-          client.authorization_endpoint = resolve_endpoint_from_host(host, config.authorization_endpoint)
-          client.token_endpoint = resolve_endpoint_from_host(host, config.token_endpoint)
-          client.userinfo_endpoint = resolve_endpoint_from_host(host, config.userinfo_endpoint)
+          client.authorization_endpoint = config.authorization_endpoint
+          client.token_endpoint = config.token_endpoint
+          client.userinfo_endpoint = config.userinfo_endpoint
+        end
+
+        # Accessor for OmniAuth DSL blocks
+        def user_info
+          @user_info
+        end
+
+        # Accessor for OmniAuth DSL blocks
+        def access_token
+          @access_token
         end
       end
     end

--- a/lib/omniauth/strategies/oidc/request.rb
+++ b/lib/omniauth/strategies/oidc/request.rb
@@ -6,15 +6,16 @@ module OmniAuth
       # Code request phase
       module Request
         def request_phase
-          @identifier = client_options.identifier
-          @secret = secret
+          OmniauthOidc::Logging.instrument("request_phase.start", provider: name) do
+            @identifier = client_options.identifier
+            @secret = secret
 
-          set_client_options_for_request_phase
-          redirect authorize_uri
+            set_client_options_for_request_phase
+            redirect authorize_uri
+          end
         end
 
         def authorize_uri # rubocop:disable Metrics/AbcSize
-          client.redirect_uri = redirect_uri
           opts = request_options
 
           opts.merge!(options.extra_authorize_params) unless options.extra_authorize_params.empty?
@@ -27,10 +28,14 @@ module OmniAuth
             verifier = options.pkce_verifier ? options.pkce_verifier.call : SecureRandom.hex(64)
 
             opts.merge!(pkce_authorize_params(verifier))
-            session["omniauth.pkce.verifier"] = verifier
+            session[session_key("pkce.verifier")] = verifier
           end
 
-          client.authorization_uri(opts.reject { |_k, v| v.nil? })
+          # Add redirect_uri and extra_params to opts
+          opts[:redirect_uri] = redirect_uri
+          opts[:extra_params] = opts.compact
+
+          client.authorization_uri(opts)
         end
 
         private
@@ -59,21 +64,20 @@ module OmniAuth
                       options.state.call
                     end
                   end
-          session["omniauth.state"] = state || SecureRandom.hex(16)
+          session[session_key("state")] = state || SecureRandom.hex(16)
         end
 
         # Parse response from OIDC endpoint and set client options for request phase
-        def set_client_options_for_request_phase # rubocop:disable Metrics/AbcSize
+        def set_client_options_for_request_phase
           client_options.host = host
-          client_options.authorization_endpoint = resolve_endpoint_from_host(host, config.authorization_endpoint)
-          client_options.token_endpoint = resolve_endpoint_from_host(host, config.token_endpoint)
-          client_options.userinfo_endpoint = resolve_endpoint_from_host(host, config.userinfo_endpoint)
-          client_options.jwks_uri = resolve_endpoint_from_host(host, config.jwks_uri)
+          client_options.authorization_endpoint = config.authorization_endpoint
+          client_options.token_endpoint = config.token_endpoint
+          client_options.userinfo_endpoint = config.userinfo_endpoint
+          client_options.jwks_uri = config.jwks_uri
 
-          return unless config.respond_to?(:end_session_endpoint)
+          return unless config.respond_to?(:end_session_endpoint) && config.end_session_endpoint
 
-          client_options.end_session_endpoint = resolve_endpoint_from_host(host,
-                                                                           config.end_session_endpoint)
+          client_options.end_session_endpoint = config.end_session_endpoint
         end
       end
     end

--- a/lib/omniauth/strategies/oidc/verify.rb
+++ b/lib/omniauth/strategies/oidc/verify.rb
@@ -27,10 +27,27 @@ module OmniAuth
                           end
         end
 
+        # Force refresh JWKS cache and retry verification
+        def public_key_with_refresh
+          OmniauthOidc::Logging.info("Force refreshing JWKS cache")
+          OmniauthOidc::JwksCache.invalidate(config.jwks_uri)
+          @public_key = nil
+          @fetch_key = nil
+          public_key
+        end
+
         private
 
         def fetch_key
-          @fetch_key ||= parse_jwk_key(::OpenIDConnect.http_client.get(config.jwks_uri).body)
+          @fetch_key ||= OmniauthOidc::JwksCache.instance.fetch(config.jwks_uri) do
+            OmniauthOidc::Logging.instrument("jwks.fetch", jwks_uri: config.jwks_uri) do
+              response = OmniauthOidc::HttpClient.get(config.jwks_uri)
+              OmniauthOidc::JwkHandler.parse_jwks(response)
+            end
+          end
+        rescue StandardError => e
+          OmniauthOidc::Logging.error("Failed to fetch JWKS", error: e.message, jwks_uri: config.jwks_uri)
+          raise OmniauthOidc::JwksFetchError, "Failed to fetch JWKS from #{config.jwks_uri}: #{e.message}"
         end
 
         def base64_decoded_jwt_secret
@@ -42,36 +59,109 @@ module OmniAuth
         def verify_id_token!(id_token)
           return unless id_token
 
-          decode_id_token(id_token).verify!(issuer: config.issuer,
-                                            client_id: client_options.identifier,
-                                            nonce: params["nonce"].presence || stored_nonce)
+          OmniauthOidc::Logging.instrument("id_token.verify", provider: name) do
+            decoded = decode_id_token(id_token)
+            verify_claims!(decoded)
+            decoded
+          end
+        end
+
+        def verify_claims!(decoded_token) # rubocop:disable Metrics/MethodLength
+          claims = decoded_token.raw_attributes
+
+          # Verify issuer
+          if config.issuer && claims["iss"] != config.issuer
+            raise OmniauthOidc::InvalidIssuerError,
+                  "Issuer mismatch. Expected: #{config.issuer}, Got: #{claims["iss"]}"
+          end
+
+          # Verify audience
+          audience = claims["aud"]
+          expected_aud = client_options.identifier
+          unless audience_matches?(audience, expected_aud)
+            raise OmniauthOidc::InvalidAudienceError,
+                  "Audience mismatch. Expected: #{expected_aud}, Got: #{audience}"
+          end
+
+          # Verify nonce if present
+          expected_nonce = params["nonce"].presence || stored_nonce
+          if expected_nonce && claims["nonce"] != expected_nonce
+            raise OmniauthOidc::InvalidNonceError,
+                  "Nonce mismatch. Expected: #{expected_nonce}, Got: #{claims["nonce"]}"
+          end
+
+          # Verify expiration
+          if claims["exp"] && Time.at(claims["exp"].to_i) < Time.now
+            raise OmniauthOidc::TokenExpiredError,
+                  "Token expired at #{Time.at(claims["exp"].to_i)}"
+          end
+
+          decoded_token
+        end
+
+        def audience_matches?(audience, expected)
+          return audience == expected if audience.is_a?(String)
+          return audience.include?(expected) if audience.is_a?(Array)
+
+          false
         end
 
         def decode_id_token(id_token)
-          decoded = JSON::JWT.decode(id_token, :skip_verification)
-          algorithm = decoded.algorithm.to_sym
+          # First decode without verification to get the algorithm and kid
+          _unverified_payload, unverified_header = JWT.decode(id_token, nil, false)
+          algorithm = unverified_header["alg"]
+          kid = unverified_header["kid"]
 
-          validate_client_algorithm!(algorithm)
+          validate_client_algorithm!(algorithm.to_sym)
 
-          keyset =
-            case algorithm
-            when :HS256, :HS384, :HS512
-              secret
+          # Get the appropriate key/secret for verification
+          key = keyset_for_algorithm(algorithm.to_sym, kid)
+
+          # Decode and verify
+          verify_signature!(id_token, key, algorithm)
+        rescue JWT::DecodeError => e
+          raise OmniauthOidc::TokenVerificationError, "Invalid JWT format: #{e.message}"
+        end
+
+        def keyset_for_algorithm(algorithm, kid = nil)
+          case algorithm
+          when :HS256, :HS384, :HS512
+            secret
+          else
+            keys = public_key
+            if keys.is_a?(Array)
+              OmniauthOidc::JwkHandler.find_key(keys, kid)
             else
-              public_key
+              keys
             end
+          end
+        end
 
-          decoded.verify!(keyset)
-          ::OpenIDConnect::ResponseObject::IdToken.new(decoded)
-        rescue JSON::JWK::Set::KidNotFound
-          # Workaround for https://github.com/nov/json-jwt/pull/92#issuecomment-824654949
-          raise if decoded&.header&.key?("kid")
+        def verify_signature!(id_token, key, algorithm)
+          # Use jwt gem to decode and verify
+          payload, _header = JWT.decode(
+            id_token,
+            key,
+            true, # verify signature
+            {
+              algorithm: algorithm,
+              verify_expiration: false # We verify this manually in verify_claims!
+            }
+          )
 
-          decoded = decode_with_each_key!(id_token, keyset)
-
-          raise unless decoded
-
-          decoded
+          # Create our custom IdToken object
+          OmniauthOidc::ResponseObjects::IdToken.new(payload.merge("algorithm" => algorithm))
+        rescue JWT::VerificationError => e
+          # Try refreshing JWKS cache and retry once
+          if key.is_a?(Array) && !@signature_retry_attempted
+            @signature_retry_attempted = true
+            OmniauthOidc::Logging.warn("Signature verification failed, refreshing JWKS and retrying")
+            refreshed_key = public_key_with_refresh
+            return verify_signature!(id_token, refreshed_key, algorithm)
+          end
+          raise OmniauthOidc::InvalidSignatureError, "JWT signature verification failed: #{e.message}"
+        rescue JWT::IncorrectAlgorithm => e
+          raise OmniauthOidc::InvalidAlgorithmError, "Unexpected JWT algorithm: #{e.message}"
         end
 
         # Check for jwt to match defined client_signing_alg
@@ -81,33 +171,9 @@ module OmniAuth
           return unless client_signing_alg
           return if algorithm == client_signing_alg
 
-          reason = "Received JWT is signed with #{algorithm}, but client_singing_alg is \
-            configured for #{client_signing_alg}"
-          raise CallbackError, error: :invalid_jwt_algorithm, reason: reason, uri: params["error_uri"]
-        end
-
-        def decode!(id_token, key)
-          ::OpenIDConnect::ResponseObject::IdToken.decode(id_token, key)
-        end
-
-        def decode_with_each_key!(id_token, keyset)
-          return unless keyset.is_a?(JSON::JWK::Set)
-
-          keyset.each do |key|
-            begin
-              decoded = decode!(id_token, key)
-            rescue JSON::JWS::VerificationFailed, JSON::JWS::UnexpectedAlgorithm, JSON::JWK::UnknownAlgorithm
-              next
-            end
-
-            return decoded if decoded
-          end
-
-          nil
-        end
-
-        def stored_nonce
-          session.delete("omniauth.nonce")
+          reason = "Received JWT is signed with #{algorithm}, but client_signing_alg is " \
+                   "configured for #{client_signing_alg}"
+          raise OmniauthOidc::InvalidAlgorithmError, reason
         end
 
         def configured_public_key
@@ -120,31 +186,15 @@ module OmniAuth
 
         def parse_x509_key(key)
           OpenSSL::X509::Certificate.new(key).public_key
+        rescue OpenSSL::X509::CertificateError => e
+          raise OmniauthOidc::TokenVerificationError, "Invalid X.509 certificate: #{e.message}"
         end
 
         def parse_jwk_key(key)
           json = key.is_a?(String) ? JSON.parse(key) : key
-          return JSON::JWK::Set.new(json["keys"]) if json.key?("keys")
-
-          JSON::JWK.new(json)
-        end
-
-        def decode(str)
-          UrlSafeBase64.decode64(str).unpack1("B*").to_i(2).to_s
-        end
-
-        def user_info
-          return @user_info if @user_info
-
-          if access_token.id_token
-            decoded = decode_id_token(access_token.id_token).raw_attributes
-
-            @user_info = ::OpenIDConnect::ResponseObject::UserInfo.new(
-              access_token.userinfo!.raw_attributes.merge(decoded)
-            )
-          else
-            @user_info = access_token.userinfo!
-          end
+          OmniauthOidc::JwkHandler.parse_jwks(json)
+        rescue JSON::ParserError => e
+          raise OmniauthOidc::TokenVerificationError, "Invalid JWK format: #{e.message}"
         end
       end
     end

--- a/lib/omniauth_oidc.rb
+++ b/lib/omniauth_oidc.rb
@@ -2,4 +2,11 @@
 
 require_relative "omniauth/oidc/version"
 require_relative "omniauth/oidc/errors"
+require_relative "omniauth/oidc/logging"
+require_relative "omniauth/oidc/jwks_cache"
+require_relative "omniauth/oidc/http_client"
+require_relative "omniauth/oidc/response_objects"
+require_relative "omniauth/oidc/client"
+require_relative "omniauth/oidc/config_fetcher"
+require_relative "omniauth/oidc/jwk_handler"
 require_relative "omniauth/strategies/oidc"

--- a/omniauth_oidc.gemspec
+++ b/omniauth_oidc.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/msuliq/omniauth_oidc"
   spec.metadata["changelog_uri"] = "https://github.com/msuliq/omniauth_oidc/blob/main/CHANGELOG.md"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -31,11 +32,12 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
-  spec.add_dependency "httparty"
-  spec.add_dependency "omniauth"
-  spec.add_dependency "openid_config_parser"
-  spec.add_dependency "openid_connect"
+  # Runtime dependencies
+  spec.add_dependency "jwt", "~> 2.7"
+  spec.add_dependency "omniauth", "~> 2.1"
+
+  # Ruby 4.0+ compatibility - ostruct no longer in default gems
+  # Users on Ruby 4.0+ should add 'gem "ostruct"' to their Gemfile
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/sig/omniauth_oidc.rbs
+++ b/sig/omniauth_oidc.rbs
@@ -1,4 +1,195 @@
 module OmniauthOidc
   VERSION: String
-  # See the writing guide of rbs: https://github.com/ruby/rbs#guides
+
+  # Errors
+  class Error < RuntimeError
+  end
+
+  class MissingCodeError < Error
+  end
+
+  class MissingIdTokenError < Error
+  end
+
+  class ConfigurationError < Error
+  end
+
+  class MissingConfigurationError < ConfigurationError
+  end
+
+  class TokenError < Error
+  end
+
+  class TokenVerificationError < TokenError
+  end
+
+  class TokenExpiredError < TokenError
+  end
+
+  class InvalidAlgorithmError < TokenError
+  end
+
+  class InvalidSignatureError < TokenError
+  end
+
+  class InvalidIssuerError < TokenError
+  end
+
+  class InvalidAudienceError < TokenError
+  end
+
+  class InvalidNonceError < TokenError
+  end
+
+  class JwksError < Error
+  end
+
+  class JwksFetchError < JwksError
+  end
+
+  class KeyNotFoundError < JwksError
+  end
+
+  # HTTP Client
+  class HttpClient
+    class HttpError < StandardError
+    end
+
+    MAX_REDIRECTS: Integer
+
+    def self.get: (String url, ?headers: Hash[String, String]) -> Hash[String, untyped]
+    def self.post: (String url, ?body: String?, ?headers: Hash[String, String]) -> Hash[String, untyped]
+  end
+
+  # OIDC Client
+  class Client
+    attr_accessor identifier: String?
+    attr_accessor secret: String?
+    attr_accessor authorization_endpoint: String?
+    attr_accessor token_endpoint: String?
+    attr_accessor userinfo_endpoint: String?
+    attr_accessor host: String?
+    attr_accessor redirect_uri: String?
+
+    def initialize: (?Hash[Symbol | String, untyped] options) -> void
+    def authorization_uri: (?Hash[Symbol, untyped] params) -> String
+    def access_token!: (?Hash[Symbol, untyped] params) -> ResponseObjects::AccessToken
+    def userinfo!: (String access_token) -> ResponseObjects::UserInfo
+  end
+
+  # JWK Handler
+  class JwkHandler
+    class KeyWithId
+      attr_accessor kid: String?
+      attr_accessor keypair: OpenSSL::PKey::PKey
+
+      def initialize: (?kid: String?, ?keypair: OpenSSL::PKey::PKey) -> void
+    end
+
+    def self.parse_jwks: (String | Hash[String, untyped] | nil jwks_data) -> Array[KeyWithId]?
+    def self.jwk_to_key: (Hash[String, untyped] jwk_data) -> KeyWithId?
+    def self.find_key: (Array[KeyWithId] keys, ?String? kid) -> OpenSSL::PKey::PKey?
+  end
+
+  # JWKS Cache
+  class JwksCache
+    DEFAULT_TTL: Integer
+
+    class CacheEntry
+      attr_accessor keys: untyped
+      attr_accessor fetched_at: Time
+
+      def initialize: (?keys: untyped, ?fetched_at: Time) -> void
+    end
+
+    def self.instance: () -> JwksCache
+    def self.clear!: () -> void
+    def self.invalidate: (String jwks_uri) -> void
+
+    attr_reader ttl: Integer
+
+    def initialize: (?ttl: Integer) -> void
+    def fetch: (String jwks_uri, ?force_refresh: bool) { () -> untyped } -> untyped
+    def valid?: (String jwks_uri) -> bool
+    def invalidate: (String jwks_uri) -> void
+    def clear!: () -> void
+    def ttl=: (Integer value) -> void
+  end
+
+  # Config Fetcher
+  class ConfigFetcher
+    class Config
+      def initialize: (?Hash[Symbol | String, untyped] attributes) -> void
+      def []: (String | Symbol key) -> untyped
+      def []=: (String | Symbol key, untyped value) -> untyped
+      def respond_to_missing?: (Symbol method_name, ?bool include_private) -> bool
+    end
+
+    def self.fetch: (String endpoint_url, ?max_retries: Integer) -> Config
+  end
+
+  # Response Objects
+  module ResponseObjects
+    class IdToken
+      attr_reader raw_attributes: Hash[String, untyped]
+
+      def initialize: (?Hash[String, untyped] attributes) -> void
+      def sub: () -> String?
+      def iss: () -> String?
+      def aud: () -> (String | Array[String])?
+      def exp: () -> Integer?
+      def iat: () -> Integer?
+      def nonce: () -> String?
+    end
+
+    class UserInfo
+      attr_reader raw_attributes: Hash[String, untyped]
+
+      def initialize: (?Hash[String, untyped] attributes) -> void
+      def sub: () -> String?
+      def name: () -> String?
+      def given_name: () -> String?
+      def family_name: () -> String?
+      def middle_name: () -> String?
+      def nickname: () -> String?
+      def preferred_username: () -> String?
+      def profile: () -> String?
+      def picture: () -> String?
+      def website: () -> String?
+      def email: () -> String?
+      def email_verified: () -> bool?
+      def gender: () -> String?
+      def birthdate: () -> String?
+      def zoneinfo: () -> String?
+      def locale: () -> String?
+      def phone_number: () -> String?
+      def phone_number_verified: () -> bool?
+      def address: () -> Hash[String, untyped]?
+      def updated_at: () -> Integer?
+    end
+
+    class AccessToken
+      attr_reader access_token: String?
+      attr_reader token_type: String?
+      attr_reader expires_in: Integer?
+      attr_reader refresh_token: String?
+      attr_reader scope: String?
+      attr_reader id_token: String?
+
+      def initialize: (?Hash[String | Symbol, untyped] attributes) -> void
+      def to_h: () -> Hash[String, untyped]
+    end
+  end
+
+  # Logging
+  module Logging
+    def self.logger: () -> Logger
+    def self.logger=: (Logger logger) -> void
+    def self.log_level=: (Integer level) -> void
+    def self.instrument: (String event_name, ?Hash[Symbol, untyped] payload) ?{ (Hash[Symbol, untyped]) -> untyped } -> untyped
+    def self.debug: (String message, ?Hash[Symbol, untyped] context) -> void
+    def self.info: (String message, ?Hash[Symbol, untyped] context) -> void
+    def self.warn: (String message, ?Hash[Symbol, untyped] context) -> void
+    def self.error: (String message, ?Hash[Symbol, untyped] context) -> void
+  end
 end

--- a/test/test_errors.rb
+++ b/test/test_errors.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestErrors < Minitest::Test
+  def test_missing_code_error_inherits_from_error
+    assert OmniauthOidc::MissingCodeError < OmniauthOidc::Error
+  end
+
+  def test_missing_id_token_error_inherits_from_error
+    assert OmniauthOidc::MissingIdTokenError < OmniauthOidc::Error
+  end
+
+  def test_configuration_error_inherits_from_error
+    assert OmniauthOidc::ConfigurationError < OmniauthOidc::Error
+  end
+
+  def test_missing_configuration_error_inherits_from_configuration_error
+    assert OmniauthOidc::MissingConfigurationError < OmniauthOidc::ConfigurationError
+  end
+
+  def test_token_error_inherits_from_error
+    assert OmniauthOidc::TokenError < OmniauthOidc::Error
+  end
+
+  def test_token_verification_error_inherits_from_token_error
+    assert OmniauthOidc::TokenVerificationError < OmniauthOidc::TokenError
+  end
+
+  def test_token_expired_error_inherits_from_token_error
+    assert OmniauthOidc::TokenExpiredError < OmniauthOidc::TokenError
+  end
+
+  def test_invalid_algorithm_error_inherits_from_token_error
+    assert OmniauthOidc::InvalidAlgorithmError < OmniauthOidc::TokenError
+  end
+
+  def test_invalid_signature_error_inherits_from_token_error
+    assert OmniauthOidc::InvalidSignatureError < OmniauthOidc::TokenError
+  end
+
+  def test_invalid_issuer_error_inherits_from_token_error
+    assert OmniauthOidc::InvalidIssuerError < OmniauthOidc::TokenError
+  end
+
+  def test_invalid_audience_error_inherits_from_token_error
+    assert OmniauthOidc::InvalidAudienceError < OmniauthOidc::TokenError
+  end
+
+  def test_invalid_nonce_error_inherits_from_token_error
+    assert OmniauthOidc::InvalidNonceError < OmniauthOidc::TokenError
+  end
+
+  def test_jwks_error_inherits_from_error
+    assert OmniauthOidc::JwksError < OmniauthOidc::Error
+  end
+
+  def test_jwks_fetch_error_inherits_from_jwks_error
+    assert OmniauthOidc::JwksFetchError < OmniauthOidc::JwksError
+  end
+
+  def test_key_not_found_error_inherits_from_jwks_error
+    assert OmniauthOidc::KeyNotFoundError < OmniauthOidc::JwksError
+  end
+
+  def test_errors_can_be_raised_with_messages
+    error = OmniauthOidc::MissingConfigurationError.new("Missing identifier")
+    assert_equal "Missing identifier", error.message
+  end
+
+  def test_errors_are_runtime_errors
+    error = OmniauthOidc::Error.new
+    assert_kind_of RuntimeError, error
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,131 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "omniauth_oidc"
 
 require "minitest/autorun"
+require "webmock/minitest"
+require "rack/test"
+
+# Disable real HTTP requests
+WebMock.disable_net_connect!(allow_localhost: true)
+
+module OmniAuthTestHelper # rubocop:disable Metrics/ModuleLength
+  def app
+    opts = test_strategy_options
+    Rack::Builder.new do
+      use OmniAuth::Test::PhonySession
+      use OmniAuth::Builder do
+        provider :oidc, opts
+      end
+      run lambda { |env|
+        [200, { "Content-Type" => "text/plain" }, [env["omniauth.auth"].to_json]]
+      }
+    end.to_app
+  end
+
+  def test_strategy_options
+    {
+      name: :oidc,
+      client_options: {
+        identifier: "test_client_id",
+        secret: "test_client_secret",
+        config_endpoint: "https://example.com/.well-known/openid-configuration",
+        scheme: "https",
+        host: "example.com",
+        port: 443
+      },
+      issuer: "https://example.com"
+    }
+  end
+
+  def mock_oidc_config
+    {
+      "issuer" => "https://example.com",
+      "authorization_endpoint" => "https://example.com/oauth/authorize",
+      "token_endpoint" => "https://example.com/oauth/token",
+      "userinfo_endpoint" => "https://example.com/oauth/userinfo",
+      "jwks_uri" => "https://example.com/oauth/jwks",
+      "end_session_endpoint" => "https://example.com/oauth/logout",
+      "scopes_supported" => %w[openid profile email],
+      "response_types_supported" => %w[code id_token],
+      "grant_types_supported" => ["authorization_code"]
+    }
+  end
+
+  def mock_jwks
+    {
+      "keys" => [
+        {
+          "kty" => "RSA",
+          "use" => "sig",
+          "kid" => "test_key_id",
+          "n" => "xGOr-H7A-PWGdN6bFJcS1AHj8SQj1LQJ0jZFqvTZ7bJC7dPCOZqZ4dBIp5Z2N_kPQ7cO8CqL5Qg0ZJYzV8bQw",
+          "e" => "AQAB"
+        }
+      ]
+    }
+  end
+
+  def mock_user_info
+    {
+      "sub" => "user123",
+      "name" => "Test User",
+      "email" => "test@example.com",
+      "email_verified" => true,
+      "preferred_username" => "testuser",
+      "given_name" => "Test",
+      "family_name" => "User",
+      "gender" => "male",
+      "picture" => "https://example.com/avatar.jpg",
+      "phone_number" => "+1234567890",
+      "website" => "https://testuser.com"
+    }
+  end
+
+  def generate_test_id_token(claims = {})
+    default_claims = {
+      "iss" => "https://example.com",
+      "sub" => "user123",
+      "aud" => "test_client_id",
+      "exp" => Time.now.to_i + 3600,
+      "iat" => Time.now.to_i,
+      "nonce" => "test_nonce"
+    }
+    JSON::JWT.new(default_claims.merge(claims)).to_s
+  end
+
+  def stub_oidc_config_request
+    stub_request(:get, "https://example.com/.well-known/openid-configuration")
+      .to_return(status: 200, body: mock_oidc_config.to_json, headers: { "Content-Type" => "application/json" })
+  end
+
+  def stub_jwks_request
+    stub_request(:get, "https://example.com/oauth/jwks")
+      .to_return(status: 200, body: mock_jwks.to_json, headers: { "Content-Type" => "application/json" })
+  end
+
+  def stub_token_request(response_body = {})
+    default_response = {
+      "access_token" => "test_access_token",
+      "token_type" => "Bearer",
+      "expires_in" => 3600,
+      "refresh_token" => "test_refresh_token",
+      "id_token" => generate_test_id_token,
+      "scope" => "openid profile email"
+    }
+
+    stub_request(:post, "https://example.com/oauth/token")
+      .to_return(
+        status: 200,
+        body: default_response.merge(response_body).to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+
+  def stub_userinfo_request(user_data = nil)
+    stub_request(:get, "https://example.com/oauth/userinfo")
+      .to_return(
+        status: 200,
+        body: (user_data || mock_user_info).to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+end

--- a/test/test_http_client.rb
+++ b/test/test_http_client.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestHttpClient < Minitest::Test
+  def setup
+    WebMock.reset!
+  end
+
+  def test_get_success
+    stub_request(:get, "https://example.com/data")
+      .to_return(status: 200, body: '{"key":"value"}', headers: { "Content-Type" => "application/json" })
+
+    result = OmniauthOidc::HttpClient.get("https://example.com/data")
+    assert_equal({ "key" => "value" }, result)
+  end
+
+  def test_post_success
+    stub_request(:post, "https://example.com/token")
+      .to_return(status: 200, body: '{"access_token":"abc"}', headers: { "Content-Type" => "application/json" })
+
+    result = OmniauthOidc::HttpClient.post("https://example.com/token", body: "grant_type=authorization_code")
+    assert_equal({ "access_token" => "abc" }, result)
+  end
+
+  def test_get_follows_redirects
+    stub_request(:get, "https://example.com/old")
+      .to_return(status: 302, headers: { "Location" => "https://example.com/new" })
+    stub_request(:get, "https://example.com/new")
+      .to_return(status: 200, body: '{"redirected":true}', headers: { "Content-Type" => "application/json" })
+
+    result = OmniauthOidc::HttpClient.get("https://example.com/old")
+    assert_equal({ "redirected" => true }, result)
+  end
+
+  def test_get_follows_multiple_redirects
+    stub_request(:get, "https://example.com/a")
+      .to_return(status: 301, headers: { "Location" => "https://example.com/b" })
+    stub_request(:get, "https://example.com/b")
+      .to_return(status: 302, headers: { "Location" => "https://example.com/c" })
+    stub_request(:get, "https://example.com/c")
+      .to_return(status: 200, body: '{"found":true}', headers: { "Content-Type" => "application/json" })
+
+    result = OmniauthOidc::HttpClient.get("https://example.com/a")
+    assert_equal({ "found" => true }, result)
+  end
+
+  def test_get_raises_on_too_many_redirects
+    (1..6).each do |i|
+      stub_request(:get, "https://example.com/r#{i}")
+        .to_return(status: 302, headers: { "Location" => "https://example.com/r#{i + 1}" })
+    end
+
+    error = assert_raises(OmniauthOidc::HttpClient::HttpError) do
+      OmniauthOidc::HttpClient.get("https://example.com/r1")
+    end
+    assert_match(/Too many redirects/, error.message)
+  end
+
+  def test_post_does_not_follow_redirects
+    stub_request(:post, "https://example.com/token")
+      .to_return(status: 302, headers: { "Location" => "https://example.com/other" })
+
+    error = assert_raises(OmniauthOidc::HttpClient::HttpError) do
+      OmniauthOidc::HttpClient.post("https://example.com/token", body: "data")
+    end
+    assert_match(/Too many redirects/, error.message)
+  end
+
+  def test_get_follows_relative_redirect
+    stub_request(:get, "https://example.com/old")
+      .to_return(status: 302, headers: { "Location" => "/new" })
+    stub_request(:get, "https://example.com/new")
+      .to_return(status: 200, body: '{"relative":true}', headers: { "Content-Type" => "application/json" })
+
+    result = OmniauthOidc::HttpClient.get("https://example.com/old")
+    assert_equal({ "relative" => true }, result)
+  end
+
+  def test_get_raises_on_http_error
+    stub_request(:get, "https://example.com/fail")
+      .to_return(status: 500, body: "Internal Server Error")
+
+    error = assert_raises(OmniauthOidc::HttpClient::HttpError) do
+      OmniauthOidc::HttpClient.get("https://example.com/fail")
+    end
+    assert_match(/500/, error.message)
+  end
+
+  def test_get_raises_on_invalid_json
+    stub_request(:get, "https://example.com/bad")
+      .to_return(status: 200, body: "not json", headers: { "Content-Type" => "application/json" })
+
+    error = assert_raises(OmniauthOidc::HttpClient::HttpError) do
+      OmniauthOidc::HttpClient.get("https://example.com/bad")
+    end
+    assert_match(/Failed to parse JSON/, error.message)
+  end
+end

--- a/test/test_jwk_handler.rb
+++ b/test/test_jwk_handler.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestJwkHandler < Minitest::Test
+  def setup
+    @rsa_key1 = OpenSSL::PKey::RSA.generate(2048)
+    @rsa_key2 = OpenSSL::PKey::RSA.generate(2048)
+  end
+
+  def jwk_data_for(key, kid:)
+    jwk = JWT::JWK.new(key)
+    # Simulate real JWKS JSON (string keys) as returned by JSON.parse
+    data = jwk.export.transform_keys(&:to_s)
+    data["kid"] = kid
+    data
+  end
+
+  def test_parse_jwks_with_single_key
+    jwks = { "keys" => [jwk_data_for(@rsa_key1, kid: "key1")] }
+
+    keys = OmniauthOidc::JwkHandler.parse_jwks(jwks)
+    assert_equal 1, keys.size
+    assert_equal "key1", keys.first.kid
+    assert_instance_of OpenSSL::PKey::RSA, keys.first.keypair
+  end
+
+  def test_parse_jwks_with_multiple_keys
+    jwks = {
+      "keys" => [
+        jwk_data_for(@rsa_key1, kid: "key1"),
+        jwk_data_for(@rsa_key2, kid: "key2")
+      ]
+    }
+
+    keys = OmniauthOidc::JwkHandler.parse_jwks(jwks)
+    assert_equal 2, keys.size
+    assert_equal "key1", keys[0].kid
+    assert_equal "key2", keys[1].kid
+  end
+
+  def test_parse_jwks_from_json_string
+    jwks = { "keys" => [jwk_data_for(@rsa_key1, kid: "key1")] }
+
+    keys = OmniauthOidc::JwkHandler.parse_jwks(jwks.to_json)
+    assert_equal 1, keys.size
+    assert_equal "key1", keys.first.kid
+  end
+
+  def test_parse_jwks_returns_nil_for_nil
+    assert_nil OmniauthOidc::JwkHandler.parse_jwks(nil)
+  end
+
+  def test_find_key_with_matching_kid
+    keys = [
+      OmniauthOidc::JwkHandler::KeyWithId.new(kid: "key1", keypair: @rsa_key1),
+      OmniauthOidc::JwkHandler::KeyWithId.new(kid: "key2", keypair: @rsa_key2)
+    ]
+
+    result = OmniauthOidc::JwkHandler.find_key(keys, "key2")
+    assert_equal @rsa_key2, result
+  end
+
+  def test_find_key_returns_first_when_no_kid
+    keys = [
+      OmniauthOidc::JwkHandler::KeyWithId.new(kid: "key1", keypair: @rsa_key1),
+      OmniauthOidc::JwkHandler::KeyWithId.new(kid: "key2", keypair: @rsa_key2)
+    ]
+
+    result = OmniauthOidc::JwkHandler.find_key(keys, nil)
+    assert_equal @rsa_key1, result
+  end
+
+  def test_find_key_returns_first_when_single_key
+    keys = [
+      OmniauthOidc::JwkHandler::KeyWithId.new(kid: "key1", keypair: @rsa_key1)
+    ]
+
+    result = OmniauthOidc::JwkHandler.find_key(keys, "nonexistent")
+    assert_equal @rsa_key1, result
+  end
+
+  def test_find_key_falls_back_to_first_when_kid_not_found
+    keys = [
+      OmniauthOidc::JwkHandler::KeyWithId.new(kid: "key1", keypair: @rsa_key1),
+      OmniauthOidc::JwkHandler::KeyWithId.new(kid: "key2", keypair: @rsa_key2)
+    ]
+
+    result = OmniauthOidc::JwkHandler.find_key(keys, "nonexistent")
+    assert_equal @rsa_key1, result
+  end
+end

--- a/test/test_jwks_cache.rb
+++ b/test/test_jwks_cache.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestJwksCache < Minitest::Test
+  def setup
+    @cache = OmniauthOidc::JwksCache.new(ttl: 3600)
+    @jwks_uri = "https://example.com/oauth/jwks"
+    @test_keys = { "keys" => [{ "kid" => "test_key", "kty" => "RSA" }] }
+  end
+
+  def teardown
+    OmniauthOidc::JwksCache.clear!
+  end
+
+  def test_singleton_instance
+    instance1 = OmniauthOidc::JwksCache.instance
+    instance2 = OmniauthOidc::JwksCache.instance
+    assert_same instance1, instance2
+  end
+
+  def test_fetch_calls_block_on_cache_miss
+    block_called = false
+    result = @cache.fetch(@jwks_uri) do
+      block_called = true
+      @test_keys
+    end
+
+    assert block_called
+    assert_equal @test_keys, result
+  end
+
+  def test_fetch_uses_cache_on_hit
+    # First call
+    @cache.fetch(@jwks_uri) { @test_keys }
+
+    # Second call - block should not be executed
+    block_called = false
+    result = @cache.fetch(@jwks_uri) do
+      block_called = true
+      { different: "data" }
+    end
+
+    refute block_called
+    assert_equal @test_keys, result
+  end
+
+  def test_fetch_with_force_refresh
+    @cache.fetch(@jwks_uri) { @test_keys }
+
+    # Force refresh should call block again
+    new_keys = { "keys" => [{ "kid" => "new_key" }] }
+    result = @cache.fetch(@jwks_uri, force_refresh: true) { new_keys }
+
+    assert_equal new_keys, result
+  end
+
+  def test_cache_expiration
+    short_ttl_cache = OmniauthOidc::JwksCache.new(ttl: 0.1) # 100ms
+
+    # First fetch
+    short_ttl_cache.fetch(@jwks_uri) { @test_keys }
+
+    # Wait for expiration
+    sleep(0.2)
+
+    # Should call block again after expiration
+    block_called = false
+    new_keys = { "keys" => [{ "kid" => "expired_key" }] }
+    result = short_ttl_cache.fetch(@jwks_uri) do
+      block_called = true
+      new_keys
+    end
+
+    assert block_called
+    assert_equal new_keys, result
+  end
+
+  def test_valid_check
+    refute @cache.valid?(@jwks_uri)
+
+    @cache.fetch(@jwks_uri) { @test_keys }
+    assert @cache.valid?(@jwks_uri)
+  end
+
+  def test_invalidate
+    @cache.fetch(@jwks_uri) { @test_keys }
+    assert @cache.valid?(@jwks_uri)
+
+    @cache.invalidate(@jwks_uri)
+    refute @cache.valid?(@jwks_uri)
+  end
+
+  def test_clear_removes_all_entries
+    @cache.fetch(@jwks_uri) { @test_keys }
+    @cache.fetch("https://other.com/jwks") { { "other" => "keys" } }
+
+    @cache.clear!
+
+    refute @cache.valid?(@jwks_uri)
+    refute @cache.valid?("https://other.com/jwks")
+  end
+
+  def test_ttl_accessor
+    assert_equal 3600, @cache.ttl
+
+    @cache.ttl = 7200
+    assert_equal 7200, @cache.ttl
+  end
+
+  def test_thread_safety
+    threads = 10.times.map do
+      Thread.new do
+        100.times do
+          @cache.fetch(@jwks_uri) { @test_keys }
+        end
+      end
+    end
+
+    threads.each(&:join)
+
+    # Should not raise any errors and cache should be valid
+    assert @cache.valid?(@jwks_uri)
+  end
+
+  def test_class_level_clear
+    OmniauthOidc::JwksCache.instance.fetch(@jwks_uri) { @test_keys }
+    assert OmniauthOidc::JwksCache.instance.valid?(@jwks_uri)
+
+    OmniauthOidc::JwksCache.clear!
+    refute OmniauthOidc::JwksCache.instance.valid?(@jwks_uri)
+  end
+
+  def test_class_level_invalidate
+    OmniauthOidc::JwksCache.instance.fetch(@jwks_uri) { @test_keys }
+    assert OmniauthOidc::JwksCache.instance.valid?(@jwks_uri)
+
+    OmniauthOidc::JwksCache.invalidate(@jwks_uri)
+    refute OmniauthOidc::JwksCache.instance.valid?(@jwks_uri)
+  end
+end

--- a/test/test_logging.rb
+++ b/test/test_logging.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestLogging < Minitest::Test
+  def setup
+    @original_logger = OmniauthOidc::Logging.logger
+    @test_logger = Logger.new(StringIO.new)
+    OmniauthOidc::Logging.logger = @test_logger
+  end
+
+  def teardown
+    OmniauthOidc::Logging.logger = @original_logger
+  end
+
+  def test_has_default_logger
+    OmniauthOidc::Logging.logger = nil
+    assert_instance_of Logger, OmniauthOidc::Logging.logger
+  end
+
+  def test_can_set_custom_logger
+    custom_logger = Logger.new($stdout)
+    OmniauthOidc::Logging.logger = custom_logger
+    assert_equal custom_logger, OmniauthOidc::Logging.logger
+  end
+
+  def test_log_level_can_be_changed
+    OmniauthOidc::Logging.log_level = Logger::DEBUG
+    assert_equal Logger::DEBUG, OmniauthOidc::Logging.logger.level
+  end
+
+  def test_debug_logging
+    OmniauthOidc::Logging.logger.level = Logger::DEBUG
+    OmniauthOidc::Logging.debug("Test debug message", context: "test")
+    # Just ensure it doesn't raise an error
+    assert true
+  end
+
+  def test_info_logging
+    OmniauthOidc::Logging.info("Test info message")
+    assert true
+  end
+
+  def test_warn_logging
+    OmniauthOidc::Logging.warn("Test warn message")
+    assert true
+  end
+
+  def test_error_logging
+    OmniauthOidc::Logging.error("Test error message")
+    assert true
+  end
+
+  def test_instrument_without_activesupport
+    # Ensure instrumentation works even without ActiveSupport
+    OmniauthOidc::Logging.instrument("test.event", payload: "data")
+    assert true # If we get here without raising, test passes
+  end
+
+  def test_instrument_with_block
+    result = OmniauthOidc::Logging.instrument("test.event") do
+      "test_result"
+    end
+    assert_equal "test_result", result
+  end
+
+  def test_sensitive_data_sanitization
+    # Logging should sanitize sensitive keys
+    OmniauthOidc::Logging.debug("Event", secret: "should_not_log", access_token: "also_hidden")
+    assert true
+  end
+end

--- a/test/test_omniauth_oidc.rb
+++ b/test/test_omniauth_oidc.rb
@@ -7,7 +7,28 @@ class TestOmniauthOidc < Minitest::Test
     refute_nil ::OmniauthOidc::VERSION
   end
 
-  def test_it_does_something_useful
-    assert true
+  def test_version_is_one_zero_zero
+    assert_equal "1.0.0", ::OmniauthOidc::VERSION
+  end
+
+  def test_error_hierarchy
+    assert OmniauthOidc::MissingCodeError < OmniauthOidc::Error
+    assert OmniauthOidc::MissingIdTokenError < OmniauthOidc::Error
+    assert OmniauthOidc::TokenError < OmniauthOidc::Error
+    assert OmniauthOidc::TokenVerificationError < OmniauthOidc::TokenError
+    assert OmniauthOidc::ConfigurationError < OmniauthOidc::Error
+  end
+
+  def test_logging_module_exists
+    assert defined?(OmniauthOidc::Logging)
+    assert OmniauthOidc::Logging.respond_to?(:logger)
+    assert OmniauthOidc::Logging.respond_to?(:instrument)
+  end
+
+  def test_jwks_cache_exists
+    assert defined?(OmniauthOidc::JwksCache)
+    instance = OmniauthOidc::JwksCache.instance
+    assert instance.respond_to?(:fetch)
+    assert instance.respond_to?(:clear!)
   end
 end

--- a/test/test_strategy_configuration.rb
+++ b/test/test_strategy_configuration.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestStrategyConfiguration < Minitest::Test
+  include OmniAuthTestHelper
+
+  def setup
+    OmniauthOidc::JwksCache.clear!
+    WebMock.reset!
+  end
+
+  def test_required_configuration_validation
+    strategy = OmniAuth::Strategies::Oidc.new(app, client_options: {})
+
+    stub_oidc_config_request
+
+    error = assert_raises(OmniauthOidc::MissingConfigurationError) do
+      strategy.send(:config)
+    end
+
+    assert_match(/identifier/, error.message)
+    assert_match(/secret/, error.message)
+    assert_match(/config_endpoint/, error.message)
+  end
+
+  def test_missing_identifier_validation
+    strategy = OmniAuth::Strategies::Oidc.new(app,
+                                              client_options: {
+                                                secret: "secret",
+                                                config_endpoint: "https://example.com/.well-known/openid-configuration"
+                                              })
+
+    error = assert_raises(OmniauthOidc::MissingConfigurationError) do
+      strategy.send(:config)
+    end
+
+    assert_match(/identifier/, error.message)
+  end
+
+  def test_missing_secret_validation
+    strategy = OmniAuth::Strategies::Oidc.new(app,
+                                              client_options: {
+                                                identifier: "test_id",
+                                                config_endpoint: "https://example.com/.well-known/openid-configuration"
+                                              })
+
+    error = assert_raises(OmniauthOidc::MissingConfigurationError) do
+      strategy.send(:config)
+    end
+
+    assert_match(/secret/, error.message)
+  end
+
+  def test_missing_config_endpoint_validation
+    strategy = OmniAuth::Strategies::Oidc.new(app,
+                                              client_options: {
+                                                identifier: "test_id",
+                                                secret: "secret"
+                                              })
+
+    error = assert_raises(OmniauthOidc::MissingConfigurationError) do
+      strategy.send(:config)
+    end
+
+    assert_match(/config_endpoint/, error.message)
+  end
+
+  def test_config_fetch_success
+    stub_oidc_config_request
+
+    strategy = OmniAuth::Strategies::Oidc.new(app, test_strategy_options)
+    config = strategy.send(:config)
+
+    assert_equal "https://example.com", config.issuer
+    assert_equal "https://example.com/oauth/authorize", config.authorization_endpoint
+    assert_equal "https://example.com/oauth/token", config.token_endpoint
+  end
+
+  def test_session_key_namespacing
+    strategy = OmniAuth::Strategies::Oidc.new(app, test_strategy_options.merge(name: :custom_provider))
+
+    key = strategy.send(:session_key, "state")
+    assert_equal "omniauth.custom_provider.state", key
+
+    nonce_key = strategy.send(:session_key, "nonce")
+    assert_equal "omniauth.custom_provider.nonce", nonce_key
+  end
+
+  def test_default_scope
+    stub_oidc_config_request
+
+    strategy = OmniAuth::Strategies::Oidc.new(app, test_strategy_options)
+    scope = strategy.send(:scope)
+
+    assert_equal "openid profile email", scope
+  end
+
+  def test_custom_scope
+    stub_oidc_config_request
+
+    strategy = OmniAuth::Strategies::Oidc.new(app, test_strategy_options.merge(scope: %w[openid custom]))
+    scope = strategy.send(:scope)
+
+    assert_equal "openid custom", scope
+  end
+
+  def test_uid_field_default
+    strategy = OmniAuth::Strategies::Oidc.new(app, test_strategy_options)
+    assert_equal "sub", strategy.options.uid_field
+  end
+
+  def test_uid_field_custom
+    strategy = OmniAuth::Strategies::Oidc.new(app, test_strategy_options.merge(uid_field: "email"))
+    assert_equal "email", strategy.options.uid_field
+  end
+
+  def test_jwks_cache_ttl_default
+    strategy = OmniAuth::Strategies::Oidc.new(app, test_strategy_options)
+    assert_equal 3600, strategy.options.jwks_cache_ttl
+  end
+
+  def test_jwks_cache_ttl_custom
+    strategy = OmniAuth::Strategies::Oidc.new(app, test_strategy_options.merge(jwks_cache_ttl: 7200))
+    assert_equal 7200, strategy.options.jwks_cache_ttl
+  end
+
+  def test_pkce_disabled_by_default
+    strategy = OmniAuth::Strategies::Oidc.new(app, test_strategy_options)
+    refute strategy.options.pkce
+  end
+
+  def test_pkce_can_be_enabled
+    strategy = OmniAuth::Strategies::Oidc.new(app, test_strategy_options.merge(pkce: true))
+    assert strategy.options.pkce
+  end
+
+  def test_send_nonce_enabled_by_default
+    strategy = OmniAuth::Strategies::Oidc.new(app, test_strategy_options)
+    assert strategy.options.send_nonce
+  end
+
+  def test_fetch_user_info_enabled_by_default
+    strategy = OmniAuth::Strategies::Oidc.new(app, test_strategy_options)
+    assert strategy.options.fetch_user_info
+  end
+end


### PR DESCRIPTION

BREAKING CHANGES:
- Remove `openid_connect`, `openid_config_parser`, `json-jwt`, `httparty` dependencies
- Replace with custom `Net::HTTP` client and `jwt` gem
- Namespace session keys with provider name `(omniauth.{provider}.state)`
- Scope now returns space-delimited String instead of Array
- Internal objects changed to `OmniauthOidc::ResponseObjects` types
- Error classes restructured under `OmniauthOidc::` namespace

Added:
- `OmniauthOidc::HttpClient` with bounded redirect following (GET only, max 5)
- `OmniauthOidc::Client` for authorization, token exchange, and userinfo
- `OmniauthOidc::ResponseObjects` (`IdToken`, `UserInfo`, `AccessToken`)
- `OmniauthOidc::ConfigFetcher` with retry support
- `OmniauthOidc::JwkHandler` with kid-based key selection
- `OmniauthOidc::JwksCache` - thread-safe with configurable TTL
- `OmniauthOidc::Logging` with `ActiveSupport::Notifications` integration
- Specific error classes for all failure modes
- Configuration validation for required options
- RBS type signatures for full public API

Fixed:
- JWK kid matching for providers with multiple signing keys
- Dead decode method referencing undefined `UrlSafeBase64`
- Scope default typo (`:open_id -> :openid`)
- `client_singing_alg` typo in error messages
- Inconsistent `AuthHash` construction

Changed:
- CI: added Ruby 4.0.1 to matrix, actions/checkout v6
- RuboCop: fixed Metrics/Metrics/CyclomaticComplexity, added NewCops: enable
- Module loading via explicit require_relative instead of Dir.glob
